### PR TITLE
Automatic generation of cover images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
 public/
 resources/
-.hugo-build.lock
+.hugo_build.lock
+venv/

--- a/assets/img/cover-template.svg
+++ b/assets/img/cover-template.svg
@@ -1,0 +1,4493 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   version="1.1"
+   id="svg1"
+   width="2560"
+   height="1280"
+   viewBox="0 0 2560 1280"
+   sodipodi:docname="8fcxhv.svg"
+   inkscape:version="1.3.2 (091e20ef0f, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1">
+    <color-profile
+       inkscape:label="sRGB IEC61966-2.1"
+       name="sRGB-IEC61966-2.1"
+       xlink:href="data:application/vnd.iccprofile;base64,AAAMbExpbm8CEAAAbW50clJHQiBYWVogB84AAgAJAAYAMQAAYWNzcE1TRlQAAAAASUVDIHNSR0IAAAAAAAAAAAAAAAAAAPbWAAEAAAAA0y1IUCAgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAARY3BydAAAAVAAAAAzZGVzYwAAAYQAAACQd3RwdAAAAhQAAAAUYmtwdAAAAigAAAAUclhZWgAAAjwAAAAUZ1hZWgAAAlAAAAAUYlhZWgAAAmQAAAAUZG1uZAAAAngAAABwZG1kZAAAAugAAACIdnVlZAAAA3AAAACGdmlldwAAA/gAAAAkbHVtaQAABBwAAAAUbWVhcwAABDAAAAAkdGVjaAAABFQAAAAMclRSQwAABGAAAAgMZ1RSQwAABGAAAAgMYlRSQwAABGAAAAgMdGV4dAAAAABDb3B5cmlnaHQgKGMpIDE5OTggSGV3bGV0dC1QYWNrYXJkIENvbXBhbnkAAGRlc2MAAAAAAAAAEnNSR0IgSUVDNjE5NjYtMi4xAAAAAAAAAAASAHMAUgBHAEIAIABJAEUAQwA2ADEAOQA2ADYALQAyAC4AMQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFhZWiAAAAAAAADzUQABAAAAARbMWFlaIAAAAAAAAAAAAAAAAAAAAABYWVogAAAAAAAAb6IAADj1AAADkFhZWiAAAAAAAABimQAAt4UAABjaWFlaIAAAAAAAACSgAAAPhAAAts9kZXNjAAAAAAAAABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAAAAAAAAAAABZJRUMgaHR0cDovL3d3dy5pZWMuY2gAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAZGVzYwAAAAAAAAAuSUVDIDYxOTY2LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAuSUVDIDYxOTY2LTIuMSBEZWZhdWx0IFJHQiBjb2xvdXIgc3BhY2UgLSBzUkdCAAAAAAAAAAAAAAAAAAAAAAAAAAAAAGRlc2MAAAAAAAAALFJlZmVyZW5jZSBWaWV3aW5nIENvbmRpdGlvbiBpbiBJRUM2MTk2Ni0yLjEAAAAAAAAAAAAAACxSZWZlcmVuY2UgVmlld2luZyBDb25kaXRpb24gaW4gSUVDNjE5NjYtMi4xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB2aWV3AAAAAAATpP4AFF8uABDPFAAD7cwABBMLAANcngAAAAFYWVogAAAAAABMCVYAUAAAAFcf521lYXMAAAAAAAAAAQAAAAAAAAAAAAAAAAAAAAAAAAKPAAAAAnNpZyAAAAAAQ1JUIGN1cnYAAAAAAAAEAAAAAAUACgAPABQAGQAeACMAKAAtADIANwA7AEAARQBKAE8AVABZAF4AYwBoAG0AcgB3AHwAgQCGAIsAkACVAJoAnwCkAKkArgCyALcAvADBAMYAywDQANUA2wDgAOUA6wDwAPYA+wEBAQcBDQETARkBHwElASsBMgE4AT4BRQFMAVIBWQFgAWcBbgF1AXwBgwGLAZIBmgGhAakBsQG5AcEByQHRAdkB4QHpAfIB+gIDAgwCFAIdAiYCLwI4AkECSwJUAl0CZwJxAnoChAKOApgCogKsArYCwQLLAtUC4ALrAvUDAAMLAxYDIQMtAzgDQwNPA1oDZgNyA34DigOWA6IDrgO6A8cD0wPgA+wD+QQGBBMEIAQtBDsESARVBGMEcQR+BIwEmgSoBLYExATTBOEE8AT+BQ0FHAUrBToFSQVYBWcFdwWGBZYFpgW1BcUF1QXlBfYGBgYWBicGNwZIBlkGagZ7BowGnQavBsAG0QbjBvUHBwcZBysHPQdPB2EHdAeGB5kHrAe/B9IH5Qf4CAsIHwgyCEYIWghuCIIIlgiqCL4I0gjnCPsJEAklCToJTwlkCXkJjwmkCboJzwnlCfsKEQonCj0KVApqCoEKmAquCsUK3ArzCwsLIgs5C1ELaQuAC5gLsAvIC+EL+QwSDCoMQwxcDHUMjgynDMAM2QzzDQ0NJg1ADVoNdA2ODakNww3eDfgOEw4uDkkOZA5/DpsOtg7SDu4PCQ8lD0EPXg96D5YPsw/PD+wQCRAmEEMQYRB+EJsQuRDXEPURExExEU8RbRGMEaoRyRHoEgcSJhJFEmQShBKjEsMS4xMDEyMTQxNjE4MTpBPFE+UUBhQnFEkUahSLFK0UzhTwFRIVNBVWFXgVmxW9FeAWAxYmFkkWbBaPFrIW1hb6Fx0XQRdlF4kXrhfSF/cYGxhAGGUYihivGNUY+hkgGUUZaxmRGbcZ3RoEGioaURp3Gp4axRrsGxQbOxtjG4obshvaHAIcKhxSHHscoxzMHPUdHh1HHXAdmR3DHeweFh5AHmoelB6+HukfEx8+H2kflB+/H+ogFSBBIGwgmCDEIPAhHCFIIXUhoSHOIfsiJyJVIoIiryLdIwojOCNmI5QjwiPwJB8kTSR8JKsk2iUJJTglaCWXJccl9yYnJlcmhya3JugnGCdJJ3onqyfcKA0oPyhxKKIo1CkGKTgpaymdKdAqAio1KmgqmyrPKwIrNitpK50r0SwFLDksbiyiLNctDC1BLXYtqy3hLhYuTC6CLrcu7i8kL1ovkS/HL/4wNTBsMKQw2zESMUoxgjG6MfIyKjJjMpsy1DMNM0YzfzO4M/E0KzRlNJ402DUTNU01hzXCNf02NzZyNq426TckN2A3nDfXOBQ4UDiMOMg5BTlCOX85vDn5OjY6dDqyOu87LTtrO6o76DwnPGU8pDzjPSI9YT2hPeA+ID5gPqA+4D8hP2E/oj/iQCNAZECmQOdBKUFqQaxB7kIwQnJCtUL3QzpDfUPARANER0SKRM5FEkVVRZpF3kYiRmdGq0bwRzVHe0fASAVIS0iRSNdJHUljSalJ8Eo3Sn1KxEsMS1NLmkviTCpMcky6TQJNSk2TTdxOJU5uTrdPAE9JT5NP3VAnUHFQu1EGUVBRm1HmUjFSfFLHUxNTX1OqU/ZUQlSPVNtVKFV1VcJWD1ZcVqlW91dEV5JX4FgvWH1Yy1kaWWlZuFoHWlZaplr1W0VblVvlXDVchlzWXSddeF3JXhpebF69Xw9fYV+zYAVgV2CqYPxhT2GiYfViSWKcYvBjQ2OXY+tkQGSUZOllPWWSZedmPWaSZuhnPWeTZ+loP2iWaOxpQ2maafFqSGqfavdrT2una/9sV2yvbQhtYG25bhJua27Ebx5veG/RcCtwhnDgcTpxlXHwcktypnMBc11zuHQUdHB0zHUodYV14XY+dpt2+HdWd7N4EXhueMx5KnmJeed6RnqlewR7Y3vCfCF8gXzhfUF9oX4BfmJ+wn8jf4R/5YBHgKiBCoFrgc2CMIKSgvSDV4O6hB2EgITjhUeFq4YOhnKG14c7h5+IBIhpiM6JM4mZif6KZIrKizCLlov8jGOMyo0xjZiN/45mjs6PNo+ekAaQbpDWkT+RqJIRknqS45NNk7aUIJSKlPSVX5XJljSWn5cKl3WX4JhMmLiZJJmQmfyaaJrVm0Kbr5wcnImc951kndKeQJ6unx2fi5/6oGmg2KFHobaiJqKWowajdqPmpFakx6U4pammGqaLpv2nbqfgqFKoxKk3qamqHKqPqwKrdavprFys0K1ErbiuLa6hrxavi7AAsHWw6rFgsdayS7LCszizrrQltJy1E7WKtgG2ebbwt2i34LhZuNG5SrnCuju6tbsuu6e8IbybvRW9j74KvoS+/796v/XAcMDswWfB48JfwtvDWMPUxFHEzsVLxcjGRsbDx0HHv8g9yLzJOsm5yjjKt8s2y7bMNcy1zTXNtc42zrbPN8+40DnQutE80b7SP9LB00TTxtRJ1MvVTtXR1lXW2Ndc1+DYZNjo2WzZ8dp22vvbgNwF3IrdEN2W3hzeot8p36/gNuC94UThzOJT4tvjY+Pr5HPk/OWE5g3mlucf56noMui86Ubp0Opb6uXrcOv77IbtEe2c7ijutO9A78zwWPDl8XLx//KM8xnzp/Q09ML1UPXe9m32+/eK+Bn4qPk4+cf6V/rn+3f8B/yY/Sn9uv5L/tz/bf//"
+       id="color-profile2" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath2">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-935.24215,-229.55931)"
+         id="path2" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath3">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-91.7545,-579.95351)"
+         id="path3" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-355.92611,-434.44171)"
+         id="path4" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath5">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-753.21752,-804.43712)"
+         id="path5" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath6">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-218.25661,-38.277301)"
+         id="path6" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath7">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-518.11961,-327.68151)"
+         id="path7" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath8">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-147.07971,-254.3428)"
+         id="path8" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath9">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-338.31701,-109.29623)"
+         id="path9" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath10">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-389.63711,-741.48482)"
+         id="path10" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath11">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-878.18522,-788.56362)"
+         id="path11" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath12">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-461.29071,-17.780025)"
+         id="path12" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath13">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-868.705,33.657376)"
+         id="path13" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath14">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-530.40952,-148.1388)"
+         id="path14" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath15">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-163.8355,-14.103225)"
+         id="path15" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath16">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-832.93165,-860.48472)"
+         id="path16" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath17">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-858.73442,-56.991826)"
+         id="path17" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath18">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-732.26952,-304.48931)"
+         id="path18" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath19">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-719.66682,-377.10731)"
+         id="path19" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath20">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-392.28131,-403.31251)"
+         id="path20" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath21">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-770.31519,-892.79162)"
+         id="path21" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath22">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-434.23451,-251.0719)"
+         id="path22" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath23">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-564.87451,-710.37082)"
+         id="path23" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath24">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(4.9069001,-897.70852)"
+         id="path24" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath25">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-372.63551,40.661776)"
+         id="path25" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath26">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-85.3711,-162.11198)"
+         id="path26" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-769.30382,-564.79661)"
+         id="path27" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath28">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-452.79461,-328.23381)"
+         id="path28" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath29">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-864.985,-255.17661)"
+         id="path29" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath30">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-96.821702,-902.70532)"
+         id="path30" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath31">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-196.50801,-374.96141)"
+         id="path31" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath32">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-734.11872,-946.50412)"
+         id="path32" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath33">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-306.50031,-644.83502)"
+         id="path33" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath34">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-24.680301,-614.83391)"
+         id="path34" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath35">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(13.004601,-393.72871)"
+         id="path35" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath36">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-283.19121,-29.095801)"
+         id="path36" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath37">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-515.99891,-11.910225)"
+         id="path37" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath38">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-437.43701,-525.11651)"
+         id="path38" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath39">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-8.7092005,-142.7493)"
+         id="path39" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath40">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-2.6190001,-770.62652)"
+         id="path40" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath41">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-939.136,-456.00521)"
+         id="path41" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath42">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-594.68761,-927.06902)"
+         id="path42" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath43">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-858.51175,-382.40291)"
+         id="path43" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath44">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-44.218601,-431.19451)"
+         id="path44" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath45">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-643.75072,20.918326)"
+         id="path45" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath46">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-868.3378,-630.01202)"
+         id="path46" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath47">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-11.690901,-476.74291)"
+         id="path47" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath48">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-218.76051,-627.78022)"
+         id="path48" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath49">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-684.23342,-172.49243)"
+         id="path49" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath50">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-282.85891,-95.408627)"
+         id="path50" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath51">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-56.975701,-692.14262)"
+         id="path51" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath52">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-55.837102,-99.860702)"
+         id="path52" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath53">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-345.14381,-715.07092)"
+         id="path53" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath54">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-62.183302,-362.16761)"
+         id="path54" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath55">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-578.12341,-879.11112)"
+         id="path55" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath56">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-297.56671,-712.29602)"
+         id="path56" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath57">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-345.61811,-872.83742)"
+         id="path57" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath58">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-385.41771,-559.25701)"
+         id="path58" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath59">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-423.42621,-309.88641)"
+         id="path59" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath60">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-601.87552,-809.69752)"
+         id="path60" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath61">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-945.4177,-798.01062)"
+         id="path61" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath62">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-933.31292,-163.1898)"
+         id="path62" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath63">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-357.78331,-366.36181)"
+         id="path63" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath64">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-791.32592,-619.59082)"
+         id="path64" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath65">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-721.49842,-586.76431)"
+         id="path65" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath66">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-728.41482,-209.69108)"
+         id="path66" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath67">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-934.9573,-538.81811)"
+         id="path67" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath68">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-945.56815,-398.22571)"
+         id="path68" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath69">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-209.173,-992.08722)"
+         id="path69" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath70">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-664.73032,-710.42722)"
+         id="path70" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath71">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-321.53361,-425.84611)"
+         id="path71" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath72">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-880.45232,-719.30042)"
+         id="path72" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath73">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-295.88551,-324.18391)"
+         id="path73" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath74">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-428.74141,-931.37272)"
+         id="path74" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath75">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-539.81182,-519.52781)"
+         id="path75" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath76">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-808.8184,-520.29721)"
+         id="path76" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath77">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-614.39032,-137.66243)"
+         id="path77" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath78">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-945.193,-999.96822)"
+         id="path78" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath79">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-418.25581,-645.74482)"
+         id="path79" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath80">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-608.49122,-493.89691)"
+         id="path80" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath81">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-816.60932,-265.471)"
+         id="path81" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath82">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-182.59881,-557.72032)"
+         id="path82" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath83">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-162.0315,-429.58981)"
+         id="path83" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath84">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-242.3158,-253.5166)"
+         id="path84" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath85">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-593.99851,-372.34691)"
+         id="path85" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath86">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-538.23022,-911.15662)"
+         id="path86" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath87">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-661.01642,-863.80832)"
+         id="path87" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath88">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-260.73121,-479.26181)"
+         id="path88" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath89">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-599.69641,-66.952277)"
+         id="path89" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath90">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-825.5173,-426.06691)"
+         id="path90" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath91">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-144.5803,-768.40222)"
+         id="path91" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath92">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-369.24141,-79.049102)"
+         id="path92" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath93">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-850.68752,-136.27028)"
+         id="path93" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath94">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-338.03581,-961.23112)"
+         id="path94" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath95">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-714.17212,-887.41612)"
+         id="path95" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath96">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-504.44071,-101.90108)"
+         id="path96" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath97">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-461.23791,-709.90412)"
+         id="path97" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath98">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-729.11792,-39.571801)"
+         id="path98" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath99">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-722.34182,-668.28092)"
+         id="path99" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath100">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-837.25705,-199.23428)"
+         id="path100" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath101">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-664.30082,-389.69241)"
+         id="path101" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath102">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-419.27671,-74.741327)"
+         id="path102" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath103">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-807.4495,16.014975)"
+         id="path103" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath104">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-865.43815,-520.11361)"
+         id="path104" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath105">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-684.87602,-332.78151)"
+         id="path105" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath106">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-26.271501,10.2879)"
+         id="path106" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath107">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-403.83511,-217.49571)"
+         id="path107" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath108">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-327.18671,-561.59251)"
+         id="path108" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath109">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-775.89789,-739.11222)"
+         id="path109" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath110">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-702.44042,-471.67961)"
+         id="path110" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath111">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-155.5054,-140.65223)"
+         id="path111" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath112">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-668.54182,-543.75461)"
+         id="path112" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath113">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-20.686801,-264.56481)"
+         id="path113" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath114">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-199.3549,-685.77482)"
+         id="path114" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath115">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-670.79531,-110.11043)"
+         id="path115" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath116">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-895.3492,-196.81133)"
+         id="path116" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath117">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-764.10782,-163.15463)"
+         id="path117" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath118">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-947.19655,-296.21991)"
+         id="path118" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath119">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-400.79501,-791.44572)"
+         id="path119" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath120">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-205.2364,-828.28692)"
+         id="path120" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath121">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-942.08252,-24.395701)"
+         id="path121" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath122">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-64.423202,-783.14122)"
+         id="path122" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath123">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-653.11382,-789.66302)"
+         id="path123" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath124">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-879.66325,-949.98172)"
+         id="path124" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath125">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-319.17691,-502.62731)"
+         id="path125" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath126">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-939.9562,-849.36402)"
+         id="path126" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath127">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-198.8002,-87.367577)"
+         id="path127" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath128">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-121.3629,20.845876)"
+         id="path128" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath129">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-105.05421,-471.29491)"
+         id="path129" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath130">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-480.13591,-213.2818)"
+         id="path130" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath131">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-393.30231,-876.35782)"
+         id="path131" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath132">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-494.97811,-469.09821)"
+         id="path132" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath133">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-837.87212,-685.24942)"
+         id="path133" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath134">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-424.33041,-482.88381)"
+         id="path134" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath135">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-563.47441,-244.88581)"
+         id="path135" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath136">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-241.38241,-526.72931)"
+         id="path136" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath137">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-878.15402,-434.58251)"
+         id="path137" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath138">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-171.56451,-621.14122)"
+         id="path138" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath139">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-949.43642,-646.34222)"
+         id="path139" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath140">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-194.90271,-888.55422)"
+         id="path140" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath141">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-153.51591,-339.95791)"
+         id="path141" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath142">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-226.7566,-306.47521)"
+         id="path142" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath143">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-86.8456,-531.70462)"
+         id="path143" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath144">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-78.913802,-237.2587)"
+         id="path144" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-516.05362,-619.08892)"
+         id="path145" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath146">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-663.12512,-262.08501)"
+         id="path146" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath147">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-275.1031,-961.20192)"
+         id="path147" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath148">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-531.12421,-662.32502)"
+         id="path148" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath149">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-734.45062,-517.74701)"
+         id="path149" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath150">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-853.0366,-580.56262)"
+         id="path150" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath151">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-465.61971,-831.09502)"
+         id="path151" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath152">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-857.20562,-754.26112)"
+         id="path152" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath153">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-832.02182,-321.58131)"
+         id="path153" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath154">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-600.12401,-641.39261)"
+         id="path154" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath155">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-307.99191,-815.59462)"
+         id="path155" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath156">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-115.5634,-846.22632)"
+         id="path156" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath157">
+      <path
+         d="M -165.505,1017.86 H 949.436 V -110.22 H -165.505 Z"
+         transform="translate(-688.18172,-942.53622)"
+         id="path157" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath314">
+      <path
+         d="M 0,960 H 1920 V 0 H 0 Z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,1280)"
+         id="path314" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath315">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1227.8232,-579.95351)"
+         id="path315" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath316">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1491.9949,-434.44171)"
+         id="path316" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath317">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1889.2863,-804.43712)"
+         id="path317" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath318">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1354.3254,-38.277301)"
+         id="path318" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath319">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1654.1884,-327.68151)"
+         id="path319" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath320">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1283.1484,-254.3428)"
+         id="path320" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath321">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1474.3857,-109.29623)"
+         id="path321" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath322">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1525.7059,-741.48482)"
+         id="path322" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath323">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1089.7554,-26.610001)"
+         id="path323" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath324">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1597.3594,-17.780025)"
+         id="path324" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath325">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-982.88155,-708.10372)"
+         id="path325" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath326">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1081.6033,-935.89892)"
+         id="path326" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath327">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1028.631,-318.54881)"
+         id="path327" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath328">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1666.4784,-148.1388)"
+         id="path328" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath329">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1299.9042,-14.103225)"
+         id="path329" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath330">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1041.0226,-97.263677)"
+         id="path330" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath331">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1868.3383,-304.48931)"
+         id="path331" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath332">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1855.7356,-377.10731)"
+         id="path332" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath333">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1076.5828,-431.30771)"
+         id="path333" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath334">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1058.9757,-832.48912)"
+         id="path334" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath335">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1528.3501,-403.31251)"
+         id="path335" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath336">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1906.3839,-892.79162)"
+         id="path336" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath337">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1570.3032,-251.0719)"
+         id="path337" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath338">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1700.9433,-710.37082)"
+         id="path338" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath339">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1131.162,-897.70852)"
+         id="path339" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath340">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1508.7042,40.661776)"
+         id="path340" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath341">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1221.4398,-162.11198)"
+         id="path341" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath342">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1905.3726,-564.79661)"
+         id="path342" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath343">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1588.8634,-328.23381)"
+         id="path343" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath344">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-984.15692,-897.71452)"
+         id="path344" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath345">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-985.41025,-349.72131)"
+         id="path345" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath346">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-981.2179,-97.349702)"
+         id="path346" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath347">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1232.8905,-902.70532)"
+         id="path347" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath348">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1332.5767,-374.96141)"
+         id="path348" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath349">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1870.1875,-946.50412)"
+         id="path349" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath350">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1442.569,-644.83502)"
+         id="path350" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath351">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1160.749,-614.83391)"
+         id="path351" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath352">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1123.0641,-393.72871)"
+         id="path352" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath353">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1419.2601,-29.095801)"
+         id="path353" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath354">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1652.0676,-11.910225)"
+         id="path354" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath355">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1573.5057,-525.11651)"
+         id="path355" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath356">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1144.7781,-142.7493)"
+         id="path356" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath357">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1138.6878,-770.62652)"
+         id="path357" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath358">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1730.7564,-927.06902)"
+         id="path358" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath359">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1062.2757,-603.35812)"
+         id="path359" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath360">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1180.2874,-431.19451)"
+         id="path360" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath361">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1779.8196,20.918326)"
+         id="path361" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath362">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1070.6953,-767.77162)"
+         id="path362" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath363">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-985.33622,-592.55581)"
+         id="path363" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath364">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-987.037,-841.63942)"
+         id="path364" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath365">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1147.7596,-476.74291)"
+         id="path365" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath366">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1354.8292,-627.78022)"
+         id="path366" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath367">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1820.3022,-172.49243)"
+         id="path367" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath368">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1418.9277,-95.408627)"
+         id="path368" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath369">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1193.0445,-692.14262)"
+         id="path369" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath370">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1191.906,-99.860702)"
+         id="path370" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath371">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1481.2125,-715.07092)"
+         id="path371" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath372">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1198.252,-362.16761)"
+         id="path372" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath373">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1714.1922,-879.11112)"
+         id="path373" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath374">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1433.6355,-712.29602)"
+         id="path374" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath375">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1481.6868,-872.83742)"
+         id="path375" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath376">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1038.7906,-793.55492)"
+         id="path376" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath377">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1521.4866,-559.25701)"
+         id="path377" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath378">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1559.4949,-309.88641)"
+         id="path378" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath379">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1737.9442,-809.69752)"
+         id="path379" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath380">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1493.8521,-366.36181)"
+         id="path380" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath381">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1927.3947,-619.59082)"
+         id="path381" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath382">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1857.5671,-586.76431)"
+         id="path382" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath383">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1864.4835,-209.69108)"
+         id="path383" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath384">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1345.2418,-992.08722)"
+         id="path384" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath385">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1800.7992,-710.42722)"
+         id="path385" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath386">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1457.6023,-425.84611)"
+         id="path386" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath387">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1431.9543,-324.18391)"
+         id="path387" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath388">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1564.8102,-931.37272)"
+         id="path388" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath389">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1675.8805,-519.52781)"
+         id="path389" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath390">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1750.459,-137.66243)"
+         id="path390" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath391">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1554.3246,-645.74482)"
+         id="path391" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath392">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1744.56,-493.89691)"
+         id="path392" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath393">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1952.6781,-265.471)"
+         id="path393" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath394">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1318.6675,-557.72032)"
+         id="path394" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath395">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1298.1003,-429.58981)"
+         id="path395" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath396">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1378.3845,-253.5166)"
+         id="path396" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath397">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1730.0673,-372.34691)"
+         id="path397" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath398">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1052.073,-202.34108)"
+         id="path398" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath399">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1674.2991,-911.15662)"
+         id="path399" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath400">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1797.0852,-863.80832)"
+         id="path400" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath401">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1396.8,-479.26181)"
+         id="path401" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath402">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1735.7652,-66.952277)"
+         id="path402" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath403">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1961.5861,-426.06691)"
+         id="path403" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath404">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1280.649,-768.40222)"
+         id="path404" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath405">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1505.3103,-79.049102)"
+         id="path405" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath406">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1474.1046,-961.23112)"
+         id="path406" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath407">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1850.2408,-887.41612)"
+         id="path407" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath408">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1640.5095,-101.90108)"
+         id="path408" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath409">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1597.3066,-709.90412)"
+         id="path409" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath410">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1865.1867,-39.571801)"
+         id="path410" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath411">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1858.4106,-668.28092)"
+         id="path411" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath412">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1800.3696,-389.69241)"
+         id="path412" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath413">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1555.3455,-74.741327)"
+         id="path413" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath414">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1128.4458,-560.17291)"
+         id="path414" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath415">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1820.9448,-332.78151)"
+         id="path415" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath416">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1162.3402,10.2879)"
+         id="path416" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath417">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1539.9039,-217.49571)"
+         id="path417" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath418">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1098.8493,-331.48301)"
+         id="path418" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath419">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1463.2555,-561.59251)"
+         id="path419" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath420">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1911.9667,-739.11222)"
+         id="path420" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath421">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1838.5092,-471.67961)"
+         id="path421" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath422">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1291.5741,-140.65223)"
+         id="path422" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath423">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1804.6107,-543.75461)"
+         id="path423" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath424">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1156.7556,-264.56481)"
+         id="path424" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath425">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1335.4237,-685.77482)"
+         id="path425" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath426">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1806.864,-110.11043)"
+         id="path426" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath427">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1900.1766,-163.15463)"
+         id="path427" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath428">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1536.8638,-791.44572)"
+         id="path428" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath429">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1341.3051,-828.28692)"
+         id="path429" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath430">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1006.6614,-657.01982)"
+         id="path430" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath431">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1053.666,-706.78362)"
+         id="path431" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath432">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1200.492,-783.14122)"
+         id="path432" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath433">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1789.1826,-789.66302)"
+         id="path433" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath434">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1455.2457,-502.62731)"
+         id="path434" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath435">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1334.869,-87.367577)"
+         id="path435" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath436">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1257.4317,20.845876)"
+         id="path436" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath437">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1001.842,-432.59861)"
+         id="path437" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath438">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1241.1229,-471.29491)"
+         id="path438" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath439">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1616.2047,-213.2818)"
+         id="path439" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath440">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1529.3712,-876.35782)"
+         id="path440" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath441">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1631.0469,-469.09821)"
+         id="path441" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath442">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1973.9409,-685.24942)"
+         id="path442" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath443">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1560.399,-482.88381)"
+         id="path443" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath444">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1699.5432,-244.88581)"
+         id="path444" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath445">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1377.4512,-526.72931)"
+         id="path445" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath446">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1016.6394,-39.304201)"
+         id="path446" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath447">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1307.6334,-621.14122)"
+         id="path447" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath448">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-991.43845,-254.3836)"
+         id="path448" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath449">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1023.1087,-529.29911)"
+         id="path449" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath450">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1330.9714,-888.55422)"
+         id="path450" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath451">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1289.5846,-339.95791)"
+         id="path451" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath452">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1362.8253,-306.47521)"
+         id="path452" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath453">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1222.9143,-531.70462)"
+         id="path453" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath454">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1214.9826,-237.2587)"
+         id="path454" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath455">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1652.1225,-619.08892)"
+         id="path455" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath456">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1799.1937,-262.08501)"
+         id="path456" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath457">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1411.1719,-961.20192)"
+         id="path457" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath458">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1071.0918,-236.8936)"
+         id="path458" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath459">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1667.193,-662.32502)"
+         id="path459" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath460">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1870.5195,-517.74701)"
+         id="path460" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath461">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1060.147,-381.60831)"
+         id="path461" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath462">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1601.6884,-831.09502)"
+         id="path462" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath463">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1736.1927,-641.39261)"
+         id="path463" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath464">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1444.0608,-815.59462)"
+         id="path464" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath465">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1251.6321,-846.22632)"
+         id="path465" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath466">
+      <path
+         d="M 970.564,1017.86 H 2085.51 V -110.22 H 970.564 Z"
+         transform="translate(-1824.2505,-942.53622)"
+         id="path466" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath619">
+      <path
+         d="M 0,960 H 1920 V 0 H 0 Z"
+         transform="matrix(1.3333333,0,0,-1.3333333,0,1280)"
+         id="path619" />
+    </clipPath>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(88.963707,0,0,-88.963707,1801.1155,77.788399)"
+       spreadMethod="pad"
+       id="linearGradient623">
+      <stop
+         style="stop-opacity:1;stop-color:#b3b3b3 icc-color(sRGB-IEC61966-2.1, 0.70195007, 0.70195007, 0.70195007);"
+         offset="0"
+         id="stop621" />
+      <stop
+         style="stop-opacity:1;stop-color:#ffffff icc-color(sRGB-IEC61966-2.1, 1, 1, 1);"
+         offset="0.346369"
+         id="stop622" />
+      <stop
+         style="stop-opacity:1;stop-color:#ffffff icc-color(sRGB-IEC61966-2.1, 1, 1, 1);"
+         offset="1"
+         id="stop623" />
+    </linearGradient>
+    <linearGradient
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(16.075716,0,0,-16.075716,1801.1155,94.119415)"
+       spreadMethod="pad"
+       id="linearGradient626">
+      <stop
+         style="stop-opacity:1;stop-color:#000000 icc-color(sRGB-IEC61966-2.1, 0, 0, 0);"
+         offset="0"
+         id="stop624" />
+      <stop
+         style="stop-opacity:1;stop-color:#212121 icc-color(sRGB-IEC61966-2.1, 0.12940979, 0.12940979, 0.12940979);"
+         offset="0.173184"
+         id="stop625" />
+      <stop
+         style="stop-opacity:1;stop-color:#212121 icc-color(sRGB-IEC61966-2.1, 0.12940979, 0.12940979, 0.12940979);"
+         offset="1"
+         id="stop626" />
+    </linearGradient>
+  </defs>
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:zoom="0.48632812"
+     inkscape:cx="1281.0281"
+     inkscape:cy="641.54218"
+     inkscape:window-width="1920"
+     inkscape:window-height="1002"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer-MC0">
+    <inkscape:page
+       x="0"
+       y="0"
+       inkscape:label="1"
+       id="page1"
+       width="2560"
+       height="1280"
+       margin="0"
+       bleed="0"
+       inkscape:export-filename="Revuo_Weekly.png"
+       inkscape:export-xdpi="96"
+       inkscape:export-ydpi="96" />
+  </sodipodi:namedview>
+  <g
+     id="layer-MC0"
+     inkscape:groupmode="layer"
+     inkscape:label="Layer 1">
+    <path
+       id="path1"
+       d="M 0,0 H 1920 V 960 H 0 Z"
+       style="fill:#ef7726 icc-color(sRGB-IEC61966-2, 0.1, 0.93699646, 0.46699524, 0.14898682);fill-opacity:1;fill-rule:nonzero;stroke:none"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,1280)" />
+    <g
+       opacity="0.300003"
+       id="g313"
+       clip-path="url(#clipPath314)">
+      <path
+         d="M 0,0 2.23,6.715 -4.7,5.288 Z M 4.724,8.043 C 4.724,7.938 4.706,7.83 4.673,7.729 L 1.351,-2.273 C 1.238,-2.613 0.953,-2.867 0.603,-2.937 0.254,-3.009 -0.107,-2.89 -0.346,-2.622 l -7,7.877 c -0.236,0.265 -0.31,0.64 -0.201,0.978 0.113,0.34 0.398,0.593 0.748,0.664 L 3.523,9.022 C 3.872,9.094 4.233,8.975 4.472,8.707 4.636,8.522 4.724,8.285 4.724,8.043"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1246.9895,973.92093)"
+         clip-path="url(#clipPath2)"
+         id="path158" />
+      <path
+         d="M 0,0 12.476,0.97 5.399,11.29 Z m 15.28,0.107 c 0,-0.146 -0.034,-0.295 -0.098,-0.431 -0.154,-0.323 -0.469,-0.537 -0.824,-0.565 l -15.93,-1.238 c -0.357,-0.029 -0.701,0.137 -0.902,0.43 -0.203,0.295 -0.23,0.674 -0.078,0.998 l 6.895,14.415 c 0.154,0.322 0.469,0.536 0.824,0.564 0.357,0.029 0.701,-0.137 0.902,-0.43 L 15.104,0.674 C 15.221,0.503 15.28,0.306 15.28,0.107"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,122.33933,506.72867)"
+         clip-path="url(#clipPath3)"
+         id="path159" />
+      <path
+         d="m 0,0 7.766,4.806 -8.043,4.321 z m 10.763,4.866 c 0,-0.345 -0.177,-0.668 -0.474,-0.849 l -10.71,-6.628 c -0.303,-0.189 -0.684,-0.201 -0.998,-0.031 -0.317,0.17 -0.516,0.494 -0.528,0.85 l -0.382,12.588 c 0,0.446 0.171,0.696 0.474,0.881 0.303,0.189 0.684,0.201 0.998,0.032 L 10.236,5.747 c 0.316,-0.17 0.516,-0.494 0.527,-0.85 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,474.56813,700.7444)"
+         clip-path="url(#clipPath4)"
+         id="path160" />
+      <path
+         d="M 0,0 45.494,7.34 16.389,43.068 Z M 48.362,6.629 C 48.362,6.51 48.34,6.389 48.298,6.274 48.169,5.94 47.874,5.7 47.522,5.643 L -1.39,-2.249 c -0.354,-0.059 -0.709,0.077 -0.936,0.355 -0.224,0.273 -0.287,0.65 -0.159,0.986 l 17.62,46.306 c 0.129,0.334 0.424,0.574 0.776,0.63 0.353,0.059 0.708,-0.078 0.935,-0.355 L 48.138,7.26 c 0.148,-0.18 0.224,-0.404 0.224,-0.631"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1004.29,207.4172)"
+         clip-path="url(#clipPath5)"
+         id="path161" />
+      <path
+         d="m 0,0 18.402,-2.896 -6.693,17.383 z m 20.956,-4.153 c 0,-0.225 -0.076,-0.447 -0.222,-0.629 -0.225,-0.278 -0.58,-0.414 -0.934,-0.36 l -21.823,3.435 c -0.351,0.057 -0.648,0.295 -0.777,0.629 -0.127,0.336 -0.07,0.709 0.156,0.988 l 13.886,17.182 c 0.224,0.277 0.58,0.414 0.933,0.359 0.352,-0.057 0.648,-0.295 0.777,-0.629 L 20.89,-3.794 c 0.045,-0.117 0.066,-0.238 0.066,-0.359"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,291.0088,1228.9636)"
+         clip-path="url(#clipPath6)"
+         id="path162" />
+      <path
+         d="M 0,0 13.559,-3.316 9.65,10.083 Z m 16.004,-4.699 c 0,-0.253 -0.098,-0.501 -0.277,-0.691 -0.248,-0.257 -0.613,-0.365 -0.961,-0.279 l -16.924,4.138 c -0.345,0.084 -0.621,0.348 -0.722,0.691 -0.094,0.338 -0.008,0.709 0.238,0.971 L 9.402,12.717 c 0.248,0.258 0.613,0.366 0.961,0.28 0.345,-0.084 0.621,-0.348 0.722,-0.691 l 4.88,-16.725 c 0.025,-0.092 0.039,-0.186 0.039,-0.28"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,690.82613,843.09133)"
+         clip-path="url(#clipPath7)"
+         id="path163" />
+      <path
+         d="m 0,0 6.973,17.117 -18.31,-2.519 z m 9.553,18.343 c 0,-0.126 -0.024,-0.256 -0.075,-0.376 L 1.199,-2.357 C 1.064,-2.689 0.763,-2.921 0.41,-2.97 0.057,-3.019 -0.297,-2.877 -0.515,-2.593 l -13.462,17.332 c -0.219,0.277 -0.277,0.656 -0.137,0.99 0.135,0.332 0.436,0.564 0.789,0.613 L 8.416,19.334 C 8.77,19.382 9.123,19.24 9.341,18.956 9.48,18.779 9.553,18.562 9.553,18.343"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,196.10627,940.87627)"
+         clip-path="url(#clipPath8)"
+         id="path164" />
+      <path
+         d="m 0,0 20.927,37.46 -42.906,-0.607 z m 23.643,38.485 c 0,-0.168 -0.043,-0.336 -0.127,-0.488 L 0.9,-2.488 c -0.173,-0.31 -0.502,-0.506 -0.859,-0.511 -0.357,-0.006 -0.689,0.181 -0.873,0.488 l -23.752,39.826 c -0.184,0.303 -0.188,0.686 -0.014,1 0.174,0.311 0.502,0.506 0.859,0.512 l 46.369,0.658 c 0.357,0.006 0.689,-0.182 0.873,-0.488 0.093,-0.156 0.14,-0.334 0.14,-0.512"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,451.08933,1134.2717)"
+         clip-path="url(#clipPath9)"
+         id="path165" />
+      <path
+         d="M 0,0 6.397,1.195 2.165,6.137 Z M 9.283,0.529 C 9.283,0.418 9.263,0.304 9.227,0.197 9.108,-0.141 8.818,-0.389 8.467,-0.453 l -9.803,-1.83 c -0.351,-0.066 -0.71,0.061 -0.943,0.332 -0.236,0.27 -0.3,0.645 -0.183,0.982 L 0.855,8.433 C 0.975,8.771 1.263,9.019 1.615,9.084 1.966,9.15 2.326,9.023 2.558,8.752 L 9.043,1.179 c 0.158,-0.183 0.24,-0.416 0.24,-0.65"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,519.51613,291.3536)"
+         clip-path="url(#clipPath10)"
+         id="path166" />
+      <path
+         d="M 0,0 2.31,35.33 -29.442,19.665 Z m 4.421,36.993 c 0,-0.021 0,-0.042 -0.002,-0.064 L 1.882,-1.857 C 1.859,-2.214 1.648,-2.531 1.328,-2.689 1.005,-2.847 0.627,-2.821 0.33,-2.624 l -32.323,21.588 c -0.297,0.202 -0.457,0.567 -0.443,0.897 0.023,0.357 0.234,0.673 0.555,0.831 L 2.978,37.89 c 0.322,0.158 0.701,0.132 0.997,-0.065 0.28,-0.187 0.446,-0.5 0.446,-0.832"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1170.9136,228.58187)"
+         clip-path="url(#clipPath11)"
+         id="path167" />
+      <path
+         d="M 0,0 1.681,12.433 -9.925,7.67 Z m 3.904,14.014 c 0,-0.044 -0.005,-0.09 -0.011,-0.134 L 1.75,-1.984 C 1.703,-2.337 1.47,-2.638 1.139,-2.775 0.809,-2.91 0.431,-2.859 0.148,-2.64 l -12.667,9.787 c -0.281,0.219 -0.431,0.57 -0.378,0.925 0.046,0.354 0.279,0.654 0.611,0.791 L 2.525,14.94 c 0.33,0.135 0.707,0.084 0.99,-0.135 0.246,-0.191 0.389,-0.484 0.389,-0.791"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,615.05427,1256.2933)"
+         clip-path="url(#clipPath12)"
+         id="path168" />
+      <path
+         d="m 0,0 23.26,27.496 -35.443,6.397 z m 26.142,28.171 c 0,-0.232 -0.082,-0.463 -0.236,-0.646 L 0.408,-2.615 c -0.23,-0.271 -0.59,-0.4 -0.941,-0.338 -0.352,0.065 -0.643,0.311 -0.764,0.647 l -13.354,37.152 c -0.117,0.332 -0.053,0.712 0.178,0.984 0.23,0.271 0.589,0.4 0.941,0.337 L 25.32,29.155 c 0.352,-0.064 0.642,-0.31 0.764,-0.646 0.039,-0.11 0.058,-0.225 0.058,-0.338"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1158.2733,1324.8765)"
+         clip-path="url(#clipPath13)"
+         id="path169" />
+      <path
+         d="m 0,0 11.097,33.258 -34.351,-7.02 z m 13.592,34.584 c 0,-0.106 -0.017,-0.213 -0.05,-0.317 L 1.349,-2.275 c -0.113,-0.34 -0.398,-0.592 -0.75,-0.664 -0.349,-0.07 -0.71,0.051 -0.946,0.316 l -25.551,28.83 c -0.237,0.267 -0.311,0.646 -0.202,0.98 0.114,0.34 0.399,0.591 0.748,0.664 l 37.744,7.713 c 0.351,0.07 0.713,-0.051 0.949,-0.316 0.164,-0.186 0.251,-0.424 0.251,-0.664"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,707.21267,1082.4816)"
+         clip-path="url(#clipPath14)"
+         id="path170" />
+      <path
+         d="M 0,0 4.852,5.088 -1.98,6.746 Z M 7.77,5.651 C 7.77,5.397 7.674,5.149 7.495,4.962 L 0.252,-2.632 c -0.248,-0.26 -0.613,-0.367 -0.961,-0.284 -0.347,0.086 -0.623,0.348 -0.722,0.692 l -2.954,10.07 c -0.1,0.341 -0.014,0.712 0.236,0.97 0.246,0.26 0.611,0.367 0.959,0.283 L 7.006,6.623 C 7.354,6.537 7.629,6.276 7.729,5.932 7.756,5.84 7.77,5.745 7.77,5.651"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,218.44733,1261.1957)"
+         clip-path="url(#clipPath15)"
+         id="path171" />
+      <path
+         d="m 0,0 51.799,1.738 -27.404,43.99 z m 54.562,0.797 c 0,-0.162 -0.039,-0.324 -0.117,-0.471 -0.168,-0.314 -0.492,-0.518 -0.85,-0.529 L -1.664,-2.056 c -0.357,-0.012 -0.693,0.168 -0.882,0.47 -0.187,0.305 -0.199,0.688 -0.033,1 l 26.025,48.782 c 0.168,0.314 0.492,0.517 0.849,0.529 0.358,0.012 0.694,-0.168 0.883,-0.471 L 54.411,1.326 c 0.1,-0.162 0.151,-0.346 0.151,-0.529"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1110.5755,132.68707)"
+         clip-path="url(#clipPath16)"
+         id="path172" />
+      <path
+         d="M 0,0 21.13,10.9 1.125,23.75 Z m 24.127,10.804 c 0,-0.016 0,-0.031 -0.002,-0.047 C 24.11,10.4 23.903,10.08 23.586,9.916 L -0.621,-2.572 c -0.318,-0.164 -0.699,-0.146 -1,0.047 -0.301,0.194 -0.488,0.535 -0.457,0.889 l 1.289,27.21 c 0.016,0.357 0.223,0.678 0.539,0.842 0.318,0.163 0.699,0.146 1,-0.047 L 23.669,11.646 c 0.286,-0.186 0.458,-0.502 0.458,-0.842"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1144.9792,1204.0109)"
+         clip-path="url(#clipPath17)"
+         id="path173" />
+      <path
+         d="M 0,0 37.052,-9.119 26.424,27.529 Z m 39.495,-10.503 c 0,-0.254 -0.098,-0.504 -0.28,-0.694 -0.246,-0.257 -0.613,-0.363 -0.958,-0.277 l -40.415,9.947 c -0.347,0.086 -0.623,0.35 -0.723,0.692 -0.093,0.339 -0.007,0.71 0.241,0.972 l 28.821,30.026 c 0.247,0.258 0.614,0.363 0.959,0.278 0.348,-0.086 0.623,-0.35 0.722,-0.692 l 11.594,-39.973 c 0.025,-0.092 0.039,-0.186 0.039,-0.279"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,976.35933,874.01427)"
+         clip-path="url(#clipPath18)"
+         id="path174" />
+      <path
+         d="M 0,0 7.389,-0.998 4.557,5.899 Z M 9.971,-2.22 C 9.971,-2.437 9.9,-2.653 9.761,-2.831 9.543,-3.114 9.191,-3.259 8.836,-3.21 l -10.818,1.46 c -0.355,0.047 -0.656,0.28 -0.793,0.612 -0.131,0.326 -0.086,0.705 0.135,0.99 L 4.034,8.493 C 4.253,8.776 4.605,8.92 4.958,8.871 5.313,8.824 5.614,8.592 5.751,8.26 L 9.896,-1.841 c 0.049,-0.121 0.075,-0.25 0.075,-0.379"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,959.55573,777.19027)"
+         clip-path="url(#clipPath19)"
+         id="path175" />
+      <path
+         d="m 0,0 45.3,-24.678 -1.277,51.572 z m 47.342,-26.385 c 0,-0.347 -0.181,-0.672 -0.478,-0.853 -0.305,-0.186 -0.685,-0.195 -1,-0.025 L -2.478,-0.928 c -0.315,0.172 -0.512,0.497 -0.521,0.854 -0.04,0.439 0.173,0.693 0.478,0.878 l 46.979,28.699 c 0.305,0.185 0.686,0.195 1,0.025 0.315,-0.171 0.512,-0.496 0.521,-0.853 l 1.363,-55.034 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,523.04173,742.25)"
+         clip-path="url(#clipPath20)"
+         id="path176" />
+      <path
+         d="M 0,0 9.652,-2.158 6.696,7.28 Z m 12.124,-3.511 c 0,-0.248 -0.092,-0.49 -0.263,-0.678 -0.242,-0.261 -0.606,-0.376 -0.955,-0.298 l -13.032,2.913 c -0.348,0.078 -0.629,0.336 -0.737,0.678 -0.099,0.341 -0.023,0.714 0.219,0.976 L 6.395,9.908 C 6.637,10.17 7,10.285 7.35,10.207 7.697,10.128 7.979,9.871 8.086,9.529 l 3.993,-12.741 c 0.03,-0.098 0.045,-0.199 0.045,-0.299"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1027.0869,89.6112)"
+         clip-path="url(#clipPath21)"
+         id="path177" />
+      <path
+         d="m 0,0 7.85,6.009 -9.129,3.794 z m 10.832,6.266 c 0,-0.308 -0.143,-0.603 -0.393,-0.794 L -0.16,-2.642 c -0.284,-0.217 -0.662,-0.265 -0.99,-0.129 -0.33,0.137 -0.562,0.44 -0.61,0.795 l -1.728,13.237 c -0.048,0.352 0.102,0.707 0.385,0.924 0.283,0.217 0.662,0.265 0.992,0.129 L 10.216,7.19 c 0.328,-0.137 0.561,-0.44 0.608,-0.795 0.005,-0.043 0.008,-0.086 0.008,-0.129"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,578.97933,945.23747)"
+         clip-path="url(#clipPath22)"
+         id="path178" />
+      <path
+         d="m 0,0 47.505,-20.417 -6.071,51.349 z m 49.701,-22.021 c 0,-0.312 -0.146,-0.611 -0.402,-0.8 -0.285,-0.215 -0.664,-0.26 -0.992,-0.117 L -2.381,-1.152 c -0.328,0.141 -0.556,0.445 -0.597,0.8 -0.051,0.354 0.107,0.706 0.395,0.918 L 41.625,33.57 c 0.285,0.215 0.664,0.26 0.992,0.117 0.328,-0.14 0.557,-0.445 0.597,-0.8 l 6.479,-54.79 c 0.006,-0.039 0.008,-0.078 0.008,-0.118"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,753.166,332.83893)"
+         clip-path="url(#clipPath23)"
+         id="path179" />
+      <path
+         d="M 0,0 34.051,11.161 7.358,35.07 Z m 37.007,10.752 c 0,-0.069 -0.008,-0.137 -0.021,-0.206 C 36.914,10.197 36.658,9.912 36.318,9.801 L -1.023,-2.441 c -0.338,-0.111 -0.711,-0.031 -0.979,0.207 -0.263,0.238 -0.382,0.602 -0.31,0.949 l 8.069,38.46 c 0.072,0.35 0.328,0.635 0.666,0.746 0.339,0.111 0.712,0.031 0.98,-0.207 L 36.675,11.495 c 0.213,-0.191 0.332,-0.462 0.332,-0.743"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,-6.5425333,83.055333)"
+         clip-path="url(#clipPath24)"
+         id="path180" />
+      <path
+         d="M 0,0 39.454,9.664 11.357,39.001 Z m 42.373,9.106 c 0,-0.094 -0.014,-0.188 -0.039,-0.28 C 42.232,8.482 41.957,8.219 41.611,8.135 L -1.207,-2.353 c -0.347,-0.086 -0.713,0.022 -0.961,0.279 -0.246,0.258 -0.333,0.629 -0.238,0.971 L 9.919,41.223 c 0.102,0.344 0.377,0.607 0.723,0.691 0.347,0.086 0.713,-0.021 0.961,-0.279 L 42.096,9.797 c 0.179,-0.188 0.277,-0.438 0.277,-0.691"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,496.84733,1334.2157)"
+         clip-path="url(#clipPath25)"
+         id="path181" />
+      <path
+         d="M 0,0 8.004,14.784 -8.802,14.323 Z m 10.707,15.83 c 0,-0.164 -0.041,-0.328 -0.121,-0.476 L 0.933,-2.476 C 0.764,-2.791 0.439,-2.99 0.082,-2.999 c -0.357,-0.01 -0.691,0.172 -0.879,0.476 l -10.616,17.274 c -0.188,0.306 -0.198,0.687 -0.028,0.999 0.17,0.315 0.494,0.514 0.852,0.523 L 9.68,16.83 c 0.357,0.01 0.691,-0.172 0.878,-0.476 0.1,-0.161 0.149,-0.342 0.149,-0.524"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,113.82813,1063.8507)"
+         clip-path="url(#clipPath26)"
+         id="path182" />
+      <path
+         d="M 0,0 5.686,-3.034 5.472,3.408 Z m 7.742,-4.731 c 0,-0.344 -0.177,-0.666 -0.47,-0.85 -0.305,-0.187 -0.686,-0.201 -1,-0.033 l -8.74,4.665 c -0.315,0.168 -0.518,0.492 -0.529,0.849 0,0.325 0.168,0.694 0.47,0.883 l 8.41,5.237 c 0.305,0.188 0.686,0.201 1,0.033 C 7.198,5.885 7.401,5.562 7.412,5.204 l 0.33,-9.902 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1025.7384,526.93787)"
+         clip-path="url(#clipPath27)"
+         id="path183" />
+      <path
+         d="m 0,0 8.211,5.011 -8.445,4.606 z m 11.21,5.06 c 0,-0.348 -0.181,-0.672 -0.478,-0.854 L -0.435,-2.609 c -0.305,-0.185 -0.688,-0.195 -1,-0.025 -0.315,0.172 -0.512,0.498 -0.522,0.855 L -2.275,11.3 c 0.028,0.352 0.176,0.692 0.479,0.877 0.304,0.185 0.687,0.195 0.999,0.023 L 10.689,5.936 C 11.003,5.766 11.201,5.44 11.21,5.083 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,603.72613,842.35493)"
+         clip-path="url(#clipPath28)"
+         id="path184" />
+      <path
+         d="M 0,0 5.544,3.351 -0.129,6.477 Z M 8.543,3.39 C 8.543,3.04 8.359,2.716 8.061,2.535 l -8.508,-5.142 c -0.307,-0.186 -0.688,-0.193 -1,-0.02 -0.313,0.172 -0.51,0.499 -0.517,0.856 l -0.197,9.939 c 0.089,0.428 0.179,0.691 0.482,0.875 0.306,0.185 0.687,0.193 1,0.019 L 8.025,4.265 C 8.338,4.093 8.535,3.767 8.543,3.409 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1153.3133,939.76453)"
+         clip-path="url(#clipPath29)"
+         id="path185" />
+      <path
+         d="m 0,0 9.246,35.258 -35.158,-9.623 z m 11.652,36.679 c 0,-0.084 -0.01,-0.17 -0.033,-0.254 L 1.494,-2.183 C 1.404,-2.529 1.137,-2.8 0.791,-2.894 0.447,-2.988 0.078,-2.892 -0.176,-2.64 l -28.372,28.072 c -0.254,0.25 -0.359,0.617 -0.264,0.964 0.09,0.346 0.358,0.617 0.703,0.711 l 38.497,10.537 c 0.344,0.093 0.713,-0.002 0.967,-0.254 0.193,-0.189 0.297,-0.447 0.297,-0.711"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,129.0956,76.392933)"
+         clip-path="url(#clipPath30)"
+         id="path186" />
+      <path
+         d="m 0,0 1.261,19.97 -17.925,-8.893 z m 3.368,21.636 c 0,-0.022 0,-0.041 -0.002,-0.063 L 1.886,-1.853 C 1.863,-2.21 1.652,-2.527 1.334,-2.687 1.013,-2.845 0.633,-2.822 0.336,-2.622 l -19.548,12.995 c -0.299,0.199 -0.461,0.541 -0.446,0.894 0.024,0.357 0.234,0.673 0.553,0.834 L 1.923,22.532 c 0.32,0.158 0.701,0.135 0.998,-0.064 0.281,-0.186 0.447,-0.498 0.447,-0.832"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,262.01067,780.05147)"
+         clip-path="url(#clipPath31)"
+         id="path187" />
+      <path
+         d="m 0,0 24.371,50.06 -55.538,-3.924 z m 27.029,51.179 c 0,-0.148 -0.033,-0.298 -0.102,-0.437 L 1.039,-2.431 C 0.883,-2.753 0.568,-2.966 0.211,-2.992 -0.145,-3.017 -0.488,-2.849 -0.687,-2.554 L -33.793,46.45 c -0.199,0.299 -0.229,0.678 -0.07,0.998 0.156,0.322 0.47,0.535 0.827,0.56 l 58.995,4.169 c 0.355,0.026 0.699,-0.142 0.898,-0.437 0.113,-0.17 0.172,-0.365 0.172,-0.561"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,978.82493,17.994533)"
+         clip-path="url(#clipPath32)"
+         id="path188" />
+      <path
+         d="m 0,0 3.206,9.513 -9.843,-1.98 z m 5.705,10.836 c 0,-0.108 -0.017,-0.215 -0.052,-0.319 L 1.341,-2.279 c -0.113,-0.34 -0.4,-0.592 -0.75,-0.662 -0.349,-0.07 -0.71,0.051 -0.947,0.32 L -9.281,7.512 c -0.238,0.265 -0.314,0.639 -0.198,0.98 0.114,0.338 0.401,0.59 0.75,0.66 l 13.238,2.664 c 0.349,0.07 0.71,-0.051 0.947,-0.321 0.164,-0.183 0.249,-0.42 0.249,-0.659"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,408.66707,420.22)"
+         clip-path="url(#clipPath33)"
+         id="path189" />
+      <path
+         d="M 0,0 12.204,3.066 3.446,12.103 Z M 15.127,2.517 C 15.127,2.425 15.116,2.333 15.088,2.244 14.991,1.9 14.717,1.634 14.371,1.547 l -15.562,-3.91 c -0.348,-0.086 -0.713,0.018 -0.963,0.276 -0.246,0.253 -0.349,0.629 -0.242,0.969 L 2,14.315 c 0.097,0.344 0.37,0.61 0.716,0.697 0.348,0.086 0.713,-0.017 0.963,-0.275 L 14.846,3.213 c 0.184,-0.19 0.281,-0.44 0.281,-0.696"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,32.907067,460.22147)"
+         clip-path="url(#clipPath34)"
+         id="path190" />
+      <path
+         d="M 0,0 20.62,6.35 4.808,21.032 Z M 23.569,5.905 C 23.569,5.831 23.561,5.756 23.543,5.682 23.463,5.335 23.206,5.055 22.864,4.95 l -23.93,-7.369 c -0.342,-0.106 -0.713,-0.022 -0.974,0.222 -0.262,0.244 -0.379,0.609 -0.295,0.955 l 5.581,24.408 c 0.08,0.348 0.337,0.627 0.679,0.733 0.342,0.105 0.713,0.021 0.974,-0.223 L 23.249,6.637 c 0.207,-0.191 0.32,-0.457 0.32,-0.732"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,-17.339467,755.0284)"
+         clip-path="url(#clipPath35)"
+         id="path191" />
+      <path
+         d="m 0,0 16.03,-6.626 -2.276,17.194 z m 18.247,-8.211 c 0,-0.309 -0.142,-0.601 -0.39,-0.793 -0.283,-0.217 -0.662,-0.267 -0.992,-0.131 l -19.23,7.95 c -0.33,0.136 -0.562,0.437 -0.609,0.792 -0.049,0.358 0.101,0.707 0.383,0.924 l 16.5,12.677 c 0.283,0.217 0.662,0.267 0.992,0.131 0.329,-0.137 0.562,-0.438 0.609,-0.793 L 18.24,-8.08 c 0.006,-0.043 0.007,-0.088 0.007,-0.131"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,377.58827,1241.2056)"
+         clip-path="url(#clipPath36)"
+         id="path192" />
+      <path
+         d="M 0,0 32.03,20.991 -2.164,38.234 Z m 35.025,21.105 c 0,-0.336 -0.168,-0.651 -0.451,-0.836 L -0.352,-2.621 c -0.298,-0.197 -0.679,-0.218 -0.999,-0.056 -0.319,0.16 -0.527,0.478 -0.547,0.836 l -2.359,41.689 c -0.033,0.37 0.148,0.695 0.449,0.893 0.299,0.197 0.68,0.218 1,0.056 l 37.284,-18.8 c 0.319,-0.16 0.528,-0.478 0.547,-0.836 0.002,-0.019 0.002,-0.037 0.002,-0.056"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,687.99853,1264.1197)"
+         clip-path="url(#clipPath37)"
+         id="path193" />
+      <path
+         d="M 0,0 25.65,3.206 10.048,23.817 Z M 28.491,2.429 C 28.491,2.298 28.466,2.165 28.413,2.04 28.275,1.71 27.97,1.482 27.616,1.437 L -1.468,-2.199 c -0.356,-0.045 -0.708,0.103 -0.922,0.389 -0.217,0.283 -0.264,0.66 -0.125,0.992 L 8.879,26.189 c 0.138,0.33 0.443,0.558 0.796,0.604 0.356,0.044 0.707,-0.104 0.922,-0.389 L 28.288,3.032 c 0.135,-0.175 0.203,-0.388 0.203,-0.603"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,583.24933,579.84467)"
+         clip-path="url(#clipPath38)"
+         id="path194" />
+      <path
+         d="M 0,0 2.415,41.381 -34.629,22.784 Z m 4.515,43.05 c 0,-0.019 0,-0.038 -0.002,-0.058 L 1.894,-1.845 c -0.021,-0.356 -0.23,-0.676 -0.549,-0.836 -0.32,-0.16 -0.7,-0.137 -0.997,0.058 l -37.521,24.688 c -0.299,0.195 -0.473,0.547 -0.449,0.895 0.021,0.355 0.23,0.675 0.549,0.835 l 40.139,20.15 c 0.32,0.16 0.701,0.136 0.997,-0.059 0.284,-0.185 0.452,-0.5 0.452,-0.836"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,11.612267,1089.6676)"
+         clip-path="url(#clipPath39)"
+         id="path195" />
+      <path
+         d="M 0,0 2.497,6.083 -4.019,5.204 Z M 5.079,7.305 C 5.079,7.176 5.053,7.047 5.004,6.926 L 1.193,-2.361 C 1.056,-2.693 0.755,-2.925 0.4,-2.972 0.047,-3.021 -0.305,-2.877 -0.523,-2.593 l -6.136,7.945 c -0.222,0.283 -0.265,0.664 -0.135,0.99 0.137,0.332 0.438,0.564 0.793,0.611 L 3.946,8.295 C 4.3,8.344 4.651,8.199 4.87,7.916 5.008,7.738 5.079,7.521 5.079,7.305"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,3.492,252.498)"
+         clip-path="url(#clipPath40)"
+         id="path196" />
+      <path
+         d="M 0,0 1.204,38.644 -32.864,20.365 Z M 3.257,40.342 V 40.311 L 1.945,-1.792 C 1.933,-2.15 1.732,-2.474 1.418,-2.642 1.103,-2.812 0.722,-2.8 0.418,-2.611 l -35.806,22.189 c -0.303,0.187 -0.448,0.511 -0.473,0.88 0.012,0.358 0.213,0.682 0.527,0.85 L 1.785,41.223 c 0.314,0.17 0.695,0.158 1,-0.031 0.294,-0.182 0.472,-0.504 0.472,-0.85"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1252.1813,671.99307)"
+         clip-path="url(#clipPath41)"
+         id="path197" />
+      <path
+         d="m 0,0 32.106,-8.635 -8.574,32.12 z m 34.518,-10.051 c 0,-0.261 -0.104,-0.517 -0.293,-0.706 -0.254,-0.254 -0.621,-0.352 -0.967,-0.258 L -2.191,-1.48 c -0.345,0.092 -0.615,0.361 -0.707,0.707 -0.087,0.349 0.008,0.713 0.26,0.965 l 25.982,25.931 c 0.254,0.254 0.621,0.351 0.967,0.258 0.346,-0.092 0.615,-0.362 0.707,-0.707 l 9.466,-35.467 c 0.022,-0.086 0.034,-0.172 0.034,-0.258"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,792.9168,43.908)"
+         clip-path="url(#clipPath42)"
+         id="path198" />
+      <path
+         d="M 0,0 7.206,0.117 3.501,6.298 Z M 9.953,-0.853 C 9.953,-1.021 9.912,-1.187 9.828,-1.339 9.654,-1.652 9.326,-1.847 8.969,-1.853 L -1.699,-2.029 c -0.355,-0.005 -0.689,0.18 -0.872,0.487 -0.188,0.306 -0.192,0.685 -0.018,0.999 L 2.593,8.783 C 2.767,9.096 3.095,9.291 3.452,9.297 3.81,9.303 4.142,9.117 4.325,8.811 L 9.811,-0.34 c 0.095,-0.158 0.142,-0.335 0.142,-0.513"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1144.6823,770.12947)"
+         clip-path="url(#clipPath43)"
+         id="path199" />
+      <path
+         d="M 0,0 7.737,0.914 3.079,7.159 Z m 10.574,0.123 c 0,-0.135 -0.028,-0.267 -0.082,-0.394 -0.141,-0.328 -0.446,-0.557 -0.801,-0.598 L -1.486,-2.187 c -0.355,-0.043 -0.705,0.108 -0.918,0.395 -0.213,0.287 -0.257,0.667 -0.117,0.991 l 4.448,10.34 c 0.141,0.328 0.446,0.556 0.801,0.598 0.355,0.042 0.705,-0.108 0.918,-0.395 l 6.729,-9.021 c 0.131,-0.176 0.199,-0.385 0.199,-0.598"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,58.958133,705.074)"
+         clip-path="url(#clipPath44)"
+         id="path200" />
+      <path
+         d="m 0,0 11.07,47.218 -46.427,-14.02 z m 13.438,48.676 c 0,-0.076 -0.007,-0.152 -0.027,-0.228 L 1.55,-2.142 C 1.47,-2.489 1.209,-2.767 0.867,-2.87 0.525,-2.974 0.154,-2.886 -0.106,-2.642 l -37.881,35.568 c -0.262,0.244 -0.381,0.607 -0.289,0.957 0.08,0.348 0.342,0.625 0.683,0.728 L 12.15,49.633 c 0.341,0.104 0.712,0.016 0.972,-0.228 0.205,-0.192 0.316,-0.455 0.316,-0.729"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,858.33427,1307.8911)"
+         clip-path="url(#clipPath45)"
+         id="path201" />
+      <path
+         d="M 0,0 3.856,13.839 -10.058,10.26 Z m 6.284,15.239 c 0,-0.09 -0.012,-0.18 -0.037,-0.268 L 1.46,-2.204 C 1.365,-2.55 1.093,-2.816 0.748,-2.905 0.4,-2.993 0.033,-2.892 -0.217,-2.636 l -12.481,12.734 c -0.25,0.253 -0.348,0.628 -0.248,0.966 0.095,0.346 0.367,0.611 0.712,0.701 l 17.268,4.442 c 0.348,0.088 0.715,-0.013 0.965,-0.269 0.185,-0.19 0.285,-0.442 0.285,-0.699"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1157.7837,439.984)"
+         clip-path="url(#clipPath46)"
+         id="path202" />
+      <path
+         d="M 0,0 7.094,4.026 0.059,8.156 Z M 10.094,4.013 V 4.005 C 10.092,3.647 9.898,3.32 9.588,3.144 L -0.517,-2.594 c -0.311,-0.177 -0.692,-0.173 -1,0.007 -0.307,0.179 -0.494,0.507 -0.494,0.863 v 0.008 l 0.082,11.62 c 0.002,0.357 0.195,0.685 0.506,0.861 0.31,0.178 0.691,0.174 1,-0.006 L 9.599,4.876 c 0.307,-0.18 0.495,-0.51 0.495,-0.863"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,15.587867,644.3428)"
+         clip-path="url(#clipPath47)"
+         id="path203" />
+      <path
+         d="m 0,0 25.51,-8.08 -5.757,26.135 z m 27.859,-9.556 c 0,-0.277 -0.115,-0.547 -0.326,-0.738 -0.264,-0.24 -0.635,-0.322 -0.977,-0.215 l -28.811,9.126 c -0.34,0.108 -0.598,0.389 -0.674,0.739 -0.076,0.34 0.037,0.71 0.303,0.953 l 22.309,20.389 c 0.264,0.241 0.635,0.323 0.976,0.215 0.34,-0.107 0.598,-0.388 0.674,-0.738 l 6.503,-29.517 c 0.015,-0.07 0.023,-0.142 0.023,-0.214"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,291.68067,442.95973)"
+         clip-path="url(#clipPath48)"
+         id="path204" />
+      <path
+         d="m 0,0 c 0,-0.853 -0.25,-1.781 -0.472,-2.603 -0.25,-0.929 -0.629,-2.327 -0.256,-2.601 0.443,-0.332 0.533,-0.959 0.201,-1.4 -0.332,-0.441 -0.959,-0.531 -1.4,-0.201 -1.457,1.09 -0.938,3.017 -0.476,4.721 0.249,0.928 0.628,2.32 0.255,2.603 -0.373,0.28 -1.609,-0.474 -2.425,-0.974 -1.431,-0.875 -3.212,-1.962 -4.671,-0.871 -1.458,1.092 -0.912,3.105 -0.478,4.724 0.252,0.925 0.628,2.325 0.254,2.605 -0.373,0.279 -1.609,-0.477 -2.428,-0.975 -1.431,-0.875 -3.212,-1.962 -4.668,-0.871 -1.459,1.096 -0.918,3.109 -0.483,4.728 0.248,0.927 0.625,2.323 0.25,2.606 -0.375,0.281 -1.613,-0.472 -2.433,-0.972 -1.431,-0.873 -3.212,-1.959 -4.671,-0.867 -0.441,0.336 -0.529,0.963 -0.201,1.4 0.332,0.441 0.957,0.531 1.4,0.201 0.375,-0.281 1.613,0.475 2.431,0.973 1.432,0.873 3.214,1.96 4.673,0.867 1.459,-1.094 0.916,-3.105 0.483,-4.726 -0.25,-0.931 -0.619,-2.335 -0.25,-2.609 0.372,-0.279 1.609,0.477 2.427,0.975 1.431,0.874 3.212,1.962 4.669,0.871 C -6.811,6.51 -7.352,4.495 -7.791,2.878 -8.039,1.953 -8.42,0.557 -8.045,0.275 c 0.373,-0.279 1.611,0.477 2.429,0.977 1.43,0.872 3.211,1.96 4.667,0.869 C -0.232,1.584 0,0.826 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,912.3112,1050.0101)"
+         clip-path="url(#clipPath49)"
+         id="path205" />
+      <path
+         d="m 0,0 c 0,-0.336 -0.172,-0.666 -0.48,-0.855 -0.473,-0.285 -1.088,-0.135 -1.375,0.336 -1.718,2.829 -6.764,1.987 -11.646,1.173 -5.537,-0.924 -11.263,-1.88 -13.684,2.107 -2.419,4.001 1.07,8.627 4.444,13.112 2.974,3.957 6.052,8.053 4.331,10.875 -1.714,2.823 -6.758,1.98 -11.638,1.162 -5.535,-0.928 -11.259,-1.887 -13.676,2.095 -2.421,3.985 1.078,8.623 4.452,13.104 2.976,3.949 6.059,8.036 4.339,10.857 -1.713,2.824 -6.758,1.978 -11.636,1.16 -5.536,-0.928 -11.259,-1.886 -13.677,2.093 -2.407,3.98 1.078,8.611 4.458,13.093 2.978,3.95 6.059,8.039 4.343,10.851 -0.289,0.473 -0.133,1.088 0.336,1.375 0.472,0.285 1.087,0.135 1.374,-0.336 2.412,-3.98 -1.077,-8.613 -4.457,-13.093 -2.978,-3.95 -6.062,-8.033 -4.343,-10.851 1.712,-2.824 6.758,-1.978 11.636,-1.16 5.536,0.928 11.259,1.887 13.676,-2.093 2.418,-3.98 -1.074,-8.613 -4.452,-13.101 -2.976,-3.95 -6.057,-8.041 -4.339,-10.86 1.713,-2.824 6.758,-1.978 11.637,-1.162 5.535,0.927 11.261,1.886 13.678,-2.095 2.421,-3.999 -1.07,-8.629 -4.445,-13.114 C -24.119,10.718 -27.193,6.624 -25.475,3.8 -23.758,0.971 -18.711,1.812 -13.831,2.626 -8.293,3.55 -2.566,4.507 -0.144,0.519 -0.047,0.358 0,0.178 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,377.1452,1152.7885)"
+         clip-path="url(#clipPath50)"
+         id="path206" />
+      <path
+         d="m 0,0 c 0,-0.106 -0.016,-0.211 -0.051,-0.316 -0.176,-0.524 -0.742,-0.807 -1.265,-0.633 -3.341,1.117 -6.837,-3.011 -10.217,-7.002 -3.809,-4.501 -7.75,-9.155 -12.376,-7.61 -4.628,1.547 -4.981,7.633 -5.323,13.518 -0.302,5.222 -0.617,10.623 -3.958,11.738 -3.335,1.115 -6.826,-3.013 -10.204,-7.006 -3.806,-4.503 -7.745,-9.156 -12.365,-7.616 -4.62,1.545 -4.969,7.63 -5.307,13.517 -0.299,5.219 -0.609,10.616 -3.943,11.729 -3.335,1.114 -6.824,-3.015 -10.203,-7.008 -3.805,-4.501 -7.742,-9.156 -12.36,-7.613 -4.614,1.54 -4.962,7.627 -5.297,13.51 -0.297,5.22 -0.604,10.617 -3.933,11.728 -0.525,0.178 -0.807,0.744 -0.633,1.265 0.176,0.524 0.742,0.807 1.266,0.633 4.614,-1.54 4.961,-7.627 5.297,-13.51 0.297,-5.22 0.604,-10.617 3.933,-11.728 3.335,-1.113 6.825,3.015 10.203,7.008 3.805,4.501 7.742,9.156 12.36,7.613 4.62,-1.542 4.97,-7.629 5.307,-13.514 0.299,-5.219 0.61,-10.619 3.943,-11.732 3.337,-1.115 6.828,3.015 10.204,7.008 3.808,4.501 7.745,9.156 12.365,7.614 4.628,-1.546 4.981,-7.633 5.323,-13.519 0.303,-5.221 0.617,-10.622 3.958,-11.737 3.343,-1.117 6.838,3.011 10.218,7.004 3.81,4.499 7.748,9.152 12.375,7.608 C -0.264,0.808 0,0.418 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,75.9676,357.1432)"
+         clip-path="url(#clipPath51)"
+         id="path207" />
+      <path
+         d="m 0,0 c 0,-0.486 -0.358,-0.914 -0.853,-0.988 -1.594,-0.235 -2.24,-2.943 -2.865,-5.563 -0.779,-3.267 -1.586,-6.647 -4.515,-7.079 -2.932,-0.431 -4.676,2.574 -6.365,5.479 -1.354,2.33 -2.754,4.738 -4.345,4.503 -1.585,-0.232 -2.23,-2.942 -2.853,-5.561 -0.777,-3.269 -1.581,-6.647 -4.51,-7.078 -2.928,-0.432 -4.671,2.573 -6.356,5.479 -1.352,2.33 -2.748,4.737 -4.333,4.503 -1.588,-0.233 -2.232,-2.941 -2.855,-5.561 -0.777,-3.267 -1.582,-6.647 -4.509,-7.077 -2.923,-0.429 -4.665,2.576 -6.348,5.481 -1.351,2.328 -2.748,4.737 -4.329,4.503 -0.547,-0.08 -1.055,0.299 -1.137,0.844 -0.07,0.548 0.297,1.056 0.844,1.136 2.925,0.43 4.667,-2.576 6.35,-5.481 1.351,-2.33 2.747,-4.737 4.329,-4.503 1.587,0.232 2.232,2.941 2.855,5.559 0.777,3.269 1.581,6.647 4.507,7.079 2.927,0.43 4.67,-2.574 6.356,-5.48 1.351,-2.329 2.747,-4.736 4.335,-4.502 1.587,0.232 2.231,2.94 2.854,5.561 0.779,3.267 1.582,6.645 4.509,7.078 2.933,0.43 4.677,-2.573 6.366,-5.479 1.353,-2.329 2.751,-4.737 4.343,-4.503 1.591,0.233 2.237,2.943 2.862,5.561 0.779,3.269 1.586,6.649 4.517,7.081 0.547,0.08 1.054,-0.299 1.136,-0.844 C -0.004,0.098 0,0.049 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,74.449467,1146.8524)"
+         clip-path="url(#clipPath52)"
+         id="path208" />
+      <path
+         d="m 0,0 c 0,-2.695 -2.929,-4.351 -5.768,-5.956 -2.435,-1.38 -4.958,-2.757 -4.736,-4.473 0.092,-0.555 -0.306,-1.053 -0.855,-1.125 -0.547,-0.074 -1.051,0.309 -1.125,0.855 -0.415,3.021 2.711,4.776 5.732,6.483 2.436,1.381 4.973,2.802 4.735,4.474 -0.229,1.669 -3.041,2.37 -5.759,3.048 -3.366,0.839 -6.848,1.706 -7.256,4.719 -0.439,3.021 2.712,4.78 5.729,6.489 2.441,1.381 4.95,2.841 4.736,4.48 -0.229,1.671 -3.041,2.372 -5.761,3.05 -3.366,0.839 -6.846,1.708 -7.256,4.721 -0.404,3.025 2.712,4.788 5.729,6.497 2.441,1.382 4.942,2.808 4.733,4.487 -0.228,1.675 -3.04,2.38 -5.76,3.06 -3.366,0.841 -6.846,1.71 -7.256,4.729 -0.104,0.539 0.307,1.051 0.855,1.125 0.547,0.074 1.051,-0.309 1.125,-0.855 0.229,-1.676 3.04,-2.38 5.76,-3.06 3.367,-0.842 6.846,-1.711 7.256,-4.73 0.41,-3.03 -2.71,-4.786 -5.727,-6.494 -2.441,-1.383 -4.989,-2.861 -4.735,-4.489 0.228,-1.672 3.04,-2.373 5.76,-3.051 3.367,-0.839 6.846,-1.708 7.257,-4.721 0.414,-3.001 -2.711,-4.78 -5.729,-6.489 -2.444,-1.38 -4.939,-2.808 -4.736,-4.479 0.229,-1.67 3.04,-2.371 5.758,-3.048 3.367,-0.84 6.849,-1.707 7.257,-4.72 C -0.012,0.347 0,0.172 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,460.19173,326.57213)"
+         clip-path="url(#clipPath53)"
+         id="path209" />
+      <path
+         d="m 0,0 c 0,-1.076 -0.297,-2.092 -1.015,-3.015 -2.455,-3.15 -7.149,-1.793 -11.689,-0.48 -3.9,1.126 -7.934,2.292 -9.554,0.209 -1.621,-2.078 0.503,-5.702 2.55,-9.204 2.386,-4.076 4.846,-8.294 2.404,-11.442 -2.451,-3.146 -7.144,-1.787 -11.681,-0.473 -3.898,1.131 -7.931,2.299 -9.547,0.221 -1.621,-2.086 0.5,-5.702 2.552,-9.201 2.388,-4.081 4.854,-8.295 2.406,-11.443 -2.449,-3.143 -7.141,-1.78 -11.677,-0.464 -3.898,1.132 -7.926,2.3 -9.541,0.226 -0.34,-0.435 -0.967,-0.513 -1.404,-0.174 -0.435,0.338 -0.515,0.965 -0.174,1.404 2.447,3.142 7.139,1.781 11.675,0.465 3.898,-1.132 7.928,-2.302 9.543,-0.227 1.617,2.074 -0.504,5.7 -2.554,9.202 -2.388,4.079 -4.855,8.287 -2.404,11.44 2.451,3.146 7.143,1.787 11.681,0.473 3.897,-1.131 7.93,-2.298 9.547,-0.221 1.611,2.078 -0.502,5.698 -2.551,9.205 -2.39,4.077 -4.856,8.291 -2.403,11.443 2.454,3.149 7.149,1.792 11.688,0.48 3.9,-1.127 7.934,-2.292 9.555,-0.209 1.626,2.082 -0.498,5.71 -2.545,9.211 -2.385,4.081 -4.844,8.301 -2.395,11.452 0.339,0.436 0.968,0.514 1.404,0.174 0.433,-0.341 0.511,-0.968 0.173,-1.404 C -7.574,15.576 -5.46,11.944 -3.411,8.436 -1.726,5.552 0,2.597 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,82.911067,797.10987)"
+         clip-path="url(#clipPath54)"
+         id="path210" />
+      <path
+         d="m 0,0 c 0,-0.263 -0.104,-0.527 -0.309,-0.723 -3.507,-3.348 -9.031,-0.823 -14.371,1.621 -4.736,2.166 -9.633,4.406 -12.16,1.992 -2.53,-2.417 -0.519,-7.411 1.428,-12.243 2.195,-5.45 4.464,-11.083 0.956,-14.436 -3.51,-3.353 -9.035,-0.83 -14.379,1.613 -4.737,2.163 -9.637,4.403 -12.165,1.985 -2.533,-2.417 -0.523,-7.416 1.425,-12.245 2.197,-5.454 4.462,-11.087 0.953,-14.44 -3.516,-3.358 -9.045,-0.837 -14.389,1.601 -4.741,2.162 -9.642,4.398 -12.177,1.977 -2.539,-2.43 -0.529,-7.423 1.416,-12.26 2.192,-5.446 4.456,-11.089 0.943,-14.445 -0.401,-0.383 -1.033,-0.368 -1.414,0.031 -0.383,0.398 -0.367,1.035 0.031,1.414 2.537,2.419 0.526,7.422 -1.415,12.257 -2.191,5.452 -4.46,11.087 -0.943,14.447 3.514,3.359 9.042,0.836 14.389,-1.601 4.739,-2.163 9.64,-4.399 12.176,-1.976 2.533,2.418 0.522,7.415 -1.425,12.247 -2.191,5.448 -4.466,11.08 -0.953,14.438 3.511,3.353 9.035,0.828 14.38,-1.613 4.737,-2.163 9.636,-4.403 12.165,-1.985 2.529,2.417 0.517,7.412 -1.427,12.243 -2.195,5.452 -4.464,11.085 -0.957,14.436 3.507,3.351 9.031,0.824 14.374,-1.619 4.734,-2.165 9.63,-4.405 12.157,-1.993 0.4,0.382 1.033,0.367 1.413,-0.032 C -0.092,0.496 0,0.248 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,770.8312,107.85187)"
+         clip-path="url(#clipPath55)"
+         id="path211" />
+      <path
+         d="m 0,0 c 0,-0.172 -0.043,-0.346 -0.137,-0.503 -0.277,-0.477 -0.89,-0.639 -1.367,-0.36 -3.409,1.988 -8.131,-1.699 -12.694,-5.262 -5.089,-3.974 -10.351,-8.083 -14.932,-5.413 -4.579,2.669 -3.601,9.271 -2.652,15.658 0.85,5.733 1.732,11.652 -1.681,13.64 -3.404,1.982 -8.119,-1.705 -12.681,-5.27 -5.085,-3.976 -10.345,-8.087 -14.918,-5.421 -4.575,2.663 -3.589,9.265 -2.638,15.653 0.857,5.727 1.735,11.645 -1.666,13.627 -3.401,1.982 -8.117,-1.705 -12.678,-5.272 -5.085,-3.976 -10.344,-8.086 -14.917,-5.423 -4.567,2.66 -3.581,9.258 -2.627,15.647 0.856,5.725 1.744,11.646 -1.655,13.624 -0.479,0.279 -0.645,0.889 -0.36,1.367 0.278,0.476 0.889,0.638 1.367,0.359 4.567,-2.657 3.581,-9.258 2.627,-15.646 -0.854,-5.722 -1.74,-11.643 1.655,-13.625 3.402,-1.979 8.118,1.707 12.677,5.273 5.087,3.975 10.346,8.088 14.919,5.422 4.569,-2.663 3.585,-9.267 2.636,-15.649 -0.85,-5.723 -1.734,-11.647 1.667,-13.631 3.402,-1.982 8.12,1.705 12.679,5.27 5.087,3.976 10.345,8.088 14.921,5.421 4.581,-2.669 3.6,-9.272 2.651,-15.658 -0.847,-5.728 -1.728,-11.648 1.682,-13.64 3.409,-1.986 8.129,1.699 12.694,5.262 5.088,3.974 10.351,8.084 14.932,5.413 C -0.178,0.678 0,0.344 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,396.7556,330.272)"
+         clip-path="url(#clipPath56)"
+         id="path212" />
+      <path
+         d="m 0,0 c 0,-0.519 -0.402,-0.959 -0.929,-0.996 -4.948,-0.348 -7.655,5.263 -10.27,10.685 -2.325,4.825 -4.731,9.812 -8.328,9.559 -3.602,-0.252 -5.288,-5.529 -6.918,-10.629 -1.834,-5.737 -3.73,-11.667 -8.684,-12.017 -4.953,-0.348 -7.662,5.261 -10.281,10.683 -2.327,4.825 -4.735,9.813 -8.337,9.559 -3.605,-0.252 -5.292,-5.528 -6.925,-10.631 -1.835,-5.735 -3.731,-11.665 -8.685,-12.014 -4.962,-0.35 -7.674,5.258 -10.297,10.683 -2.333,4.823 -4.745,9.81 -8.353,9.556 -3.611,-0.254 -5.302,-5.53 -6.938,-10.632 -1.84,-5.736 -3.74,-11.668 -8.701,-12.017 -0.551,-0.039 -1.029,0.377 -1.068,0.927 -0.049,0.512 0.375,1.029 0.927,1.069 3.611,0.253 5.302,5.53 6.938,10.632 1.84,5.735 3.74,11.667 8.701,12.016 4.96,0.348 7.673,-5.258 10.295,-10.681 2.331,-4.825 4.745,-9.812 8.355,-9.558 3.603,0.252 5.29,5.528 6.922,10.628 1.836,5.738 3.732,11.668 8.688,12.017 4.954,0.348 7.662,-5.26 10.281,-10.683 2.327,-4.825 4.735,-9.812 8.338,-9.558 3.601,0.252 5.287,5.528 6.918,10.63 1.834,5.735 3.73,11.668 8.684,12.015 4.948,0.348 7.654,-5.261 10.269,-10.685 C -7.071,5.735 -4.667,0.748 -1.07,1 -0.519,1.039 -0.041,0.623 -0.002,0.072 0,0.049 0,0.025 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,460.82413,116.2168)"
+         clip-path="url(#clipPath57)"
+         id="path213" />
+      <path
+         d="m 0,0 c 0,-0.223 -0.035,-0.455 -0.112,-0.695 -0.546,-1.734 -2.622,-1.888 -4.291,-2.013 -0.953,-0.071 -2.393,-0.178 -2.533,-0.621 -0.117,-0.434 0.974,-1.353 1.716,-1.959 1.293,-1.058 2.9,-2.386 2.357,-4.11 -0.547,-1.734 -2.622,-1.887 -4.29,-2.01 -0.953,-0.068 -2.392,-0.175 -2.532,-0.615 -0.124,-0.433 0.978,-1.353 1.718,-1.96 1.293,-1.059 2.913,-2.384 2.357,-4.108 -0.549,-1.733 -2.623,-1.885 -4.29,-2.008 -0.953,-0.068 -2.392,-0.174 -2.531,-0.613 -0.166,-0.528 -0.726,-0.818 -1.253,-0.652 -0.524,0.166 -0.819,0.732 -0.653,1.253 0.547,1.732 2.623,1.885 4.29,2.008 0.953,0.068 2.392,0.174 2.531,0.615 0.134,0.406 -0.978,1.353 -1.718,1.959 -1.293,1.056 -2.914,2.376 -2.357,4.108 0.546,1.734 2.622,1.886 4.29,2.009 0.952,0.069 2.392,0.176 2.532,0.615 0.127,0.453 -0.976,1.357 -1.718,1.963 -1.294,1.058 -2.904,2.393 -2.355,4.108 0.549,1.734 2.625,1.888 4.29,2.013 0.953,0.07 2.394,0.178 2.535,0.621 0.115,0.408 -0.977,1.357 -1.717,1.964 -1.292,1.063 -2.898,2.393 -2.355,4.113 0.166,0.527 0.727,0.818 1.254,0.652 0.527,-0.164 0.816,-0.726 0.652,-1.253 -0.132,-0.44 0.975,-1.36 1.717,-1.965 C -1.351,2.505 0,1.4 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,513.89027,534.324)"
+         clip-path="url(#clipPath58)"
+         id="path214" />
+      <path
+         d="m 0,0 c 0,-0.34 -0.174,-0.671 -0.488,-0.859 -4.762,-2.839 -10.34,1.437 -15.735,5.573 -4.864,3.73 -9.894,7.586 -13.493,5.442 -3.604,-2.148 -2.609,-8.41 -1.642,-14.463 1.068,-6.712 2.176,-13.656 -2.593,-16.497 -4.766,-2.841 -10.347,1.434 -15.744,5.567 -4.868,3.728 -9.9,7.585 -13.505,5.435 -3.603,-2.148 -2.607,-8.409 -1.646,-14.466 1.066,-6.713 2.169,-13.657 -2.597,-16.498 -4.774,-2.845 -10.359,1.425 -15.758,5.557 -4.872,3.726 -9.91,7.581 -13.523,5.427 -3.612,-2.152 -2.622,-8.416 -1.657,-14.473 1.058,-6.719 2.163,-13.663 -2.611,-16.506 -0.475,-0.283 -1.088,-0.127 -1.371,0.347 -0.283,0.469 -0.131,1.086 0.348,1.371 3.61,2.152 2.618,8.418 1.657,14.473 -1.064,6.716 -2.167,13.66 2.611,16.506 4.776,2.845 10.361,-1.425 15.76,-5.557 4.872,-3.726 9.908,-7.58 13.52,-5.426 3.605,2.149 2.611,8.412 1.647,14.467 -1.068,6.709 -2.172,13.655 2.597,16.496 4.766,2.841 10.347,-1.433 15.744,-5.567 4.868,-3.728 9.9,-7.584 13.505,-5.434 3.6,2.144 2.607,8.404 1.642,14.463 -1.068,6.71 -2.175,13.657 2.593,16.496 4.763,2.839 10.34,-1.437 15.735,-5.573 C -10.14,2.572 -5.11,-1.285 -1.511,0.859 -1.037,1.143 -0.423,0.986 -0.14,0.512 -0.045,0.352 0,0.176 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,564.56827,866.81813)"
+         clip-path="url(#clipPath59)"
+         id="path215" />
+      <path
+         d="m 0,0 c 0,-2.138 -0.576,-3.977 -2.263,-5.218 -3.55,-2.607 -8.178,0.274 -12.654,3.06 -3.909,2.435 -7.953,4.954 -10.413,3.146 -2.454,-1.8 -1.258,-6.409 -0.102,-10.868 1.322,-5.105 2.689,-10.379 -0.855,-12.984 -3.546,-2.605 -8.17,0.279 -12.642,3.07 -3.907,2.437 -7.947,4.955 -10.401,3.153 -2.455,-1.802 -1.258,-6.412 -0.1,-10.868 1.32,-5.103 2.695,-10.375 -0.851,-12.982 -3.543,-2.601 -8.164,0.285 -12.636,3.076 -3.906,2.439 -7.944,4.96 -10.394,3.159 -0.446,-0.326 -1.07,-0.23 -1.398,0.215 -0.325,0.439 -0.235,1.068 0.214,1.398 3.542,2.601 8.167,-0.285 12.638,-3.076 3.904,-2.436 7.942,-4.957 10.392,-3.159 2.451,1.801 1.254,6.409 0.1,10.867 -1.326,5.102 -2.695,10.376 0.851,12.983 3.546,2.603 8.17,-0.281 12.644,-3.069 3.907,-2.437 7.945,-4.956 10.4,-3.154 2.454,1.8 1.255,6.411 0.101,10.869 -1.324,5.104 -2.688,10.376 0.855,12.983 3.552,2.607 8.18,-0.273 12.656,-3.062 3.909,-2.433 7.951,-4.952 10.412,-3.144 2.458,1.805 1.265,6.415 0.111,10.877 -1.32,5.102 -2.689,10.378 0.865,12.989 0.445,0.326 1.07,0.23 1.398,-0.215 C -0.748,19.605 -0.84,18.98 -1.287,18.648 -3.749,16.84 -2.554,12.232 -1.398,7.771 -0.705,5.092 0,2.365 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,802.50067,200.40333)"
+         clip-path="url(#clipPath60)"
+         id="path216" />
+      <path
+         d="m 0,0 c 0,-0.047 -0.004,-0.094 -0.01,-0.14 -0.576,-4.087 -5.512,-5.292 -10.284,-6.456 -4.127,-1.007 -8.393,-2.048 -8.78,-4.792 -0.383,-2.777 3.425,-4.93 7.114,-7.039 4.265,-2.439 8.695,-4.976 8.099,-9.051 -0.576,-4.091 -5.512,-5.298 -10.286,-6.465 -4.126,-1.008 -8.395,-2.051 -8.781,-4.8 -0.387,-2.761 3.424,-4.933 7.113,-7.041 4.265,-2.441 8.707,-4.95 8.1,-9.055 -0.576,-4.097 -5.514,-5.307 -10.289,-6.477 -4.128,-1.011 -8.394,-2.056 -8.783,-4.811 -0.352,-2.711 3.425,-4.939 7.114,-7.053 4.265,-2.443 8.68,-4.966 8.097,-9.067 -0.076,-0.546 -0.582,-0.927 -1.128,-0.851 -0.547,0.078 -0.912,0.609 -0.852,1.129 0.381,2.77 -3.423,4.94 -7.113,7.053 -4.263,2.445 -8.684,4.987 -8.098,9.066 0.576,4.097 5.514,5.308 10.289,6.477 4.128,1.012 8.394,2.056 8.783,4.812 0.361,2.769 -3.427,4.932 -7.114,7.041 -4.265,2.439 -8.695,4.965 -8.099,9.054 0.576,4.091 5.512,5.298 10.286,6.466 4.126,1.007 8.395,2.05 8.781,4.799 0.387,2.769 -3.426,4.929 -7.113,7.038 -4.263,2.441 -8.678,4.921 -8.1,9.054 0.574,4.085 5.511,5.29 10.285,6.454 4.126,1.007 8.392,2.048 8.779,4.792 0.076,0.546 0.582,0.927 1.129,0.851 C -0.362,0.918 0,0.49 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1260.5569,215.98587)"
+         clip-path="url(#clipPath61)"
+         id="path217" />
+      <path
+         d="m 0,0 c 0,-0.054 -0.004,-0.111 -0.014,-0.166 -0.562,-3.38 -4.587,-4.257 -8.48,-5.104 -3.24,-0.707 -6.592,-1.437 -6.932,-3.48 -0.318,-1.994 2.593,-3.819 5.434,-5.54 3.411,-2.063 6.965,-4.184 6.372,-7.578 -0.563,-3.384 -4.589,-4.263 -8.481,-5.112 -3.241,-0.709 -6.594,-1.441 -6.933,-3.487 -0.317,-2.018 2.593,-3.822 5.432,-5.542 3.411,-2.062 6.963,-4.206 6.371,-7.583 -0.562,-3.385 -4.587,-4.268 -8.478,-5.119 -3.243,-0.711 -6.596,-1.445 -6.938,-3.497 -0.315,-2.022 2.593,-3.83 5.432,-5.552 3.408,-2.066 6.927,-4.204 6.368,-7.59 -0.09,-0.545 -0.605,-0.912 -1.15,-0.822 -0.545,0.092 -0.928,0.607 -0.822,1.15 0.334,2.05 -2.591,3.831 -5.432,5.551 -3.41,2.064 -6.936,4.209 -6.368,7.591 0.562,3.388 4.588,4.27 8.48,5.121 3.244,0.711 6.594,1.445 6.936,3.496 0.34,2.062 -2.597,3.825 -5.434,5.543 -3.412,2.064 -6.928,4.218 -6.37,7.581 0.562,3.384 4.587,4.262 8.479,5.112 3.243,0.709 6.594,1.441 6.936,3.487 0.339,2.035 -2.594,3.822 -5.435,5.54 -3.409,2.064 -6.949,4.204 -6.371,7.578 0.562,3.38 4.587,4.257 8.48,5.104 3.24,0.707 6.592,1.438 6.932,3.48 0.09,0.545 0.606,0.912 1.15,0.822 C -0.346,0.902 0,0.479 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1244.4172,1062.4136)"
+         clip-path="url(#clipPath62)"
+         id="path218" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.582 -0.367,-0.783 -1.162,-0.971 -2.593,-0.197 -3.741,0.426 -0.45,0.242 -1.283,0.693 -1.537,0.636 -0.043,-0.207 0.234,-1.103 0.396,-1.589 0.405,-1.244 0.908,-2.787 -0.248,-3.761 -1.163,-0.97 -2.595,-0.197 -3.745,0.426 -0.449,0.242 -1.283,0.693 -1.537,0.636 -0.074,-0.212 0.235,-1.105 0.395,-1.591 0.404,-1.244 0.915,-2.79 -0.25,-3.761 -1.162,-0.971 -2.595,-0.199 -3.745,0.422 -0.45,0.242 -1.285,0.693 -1.539,0.634 -0.074,-0.197 0.232,-1.109 0.39,-1.593 0.405,-1.244 0.912,-2.792 -0.252,-3.761 -0.423,-0.353 -1.054,-0.297 -1.408,0.127 -0.353,0.422 -0.298,1.052 0.128,1.408 0.082,0.228 -0.21,1.121 -0.368,1.605 -0.406,1.24 -0.913,2.788 0.252,3.761 1.162,0.972 2.595,0.199 3.745,-0.422 0.452,-0.242 1.287,-0.693 1.539,-0.635 0.049,0.198 -0.234,1.11 -0.392,1.592 -0.406,1.24 -0.918,2.788 0.25,3.761 1.161,0.97 2.593,0.197 3.743,-0.426 0.449,-0.242 1.283,-0.693 1.537,-0.636 0.066,0.218 -0.238,1.109 -0.397,1.591 -0.408,1.242 -0.91,2.79 0.25,3.759 1.162,0.97 2.593,0.197 3.742,-0.426 0.449,-0.242 1.283,-0.693 1.536,-0.637 0.424,0.356 1.041,0.292 1.395,-0.132 C -0.074,0.447 0,0.225 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,477.0444,791.5176)"
+         clip-path="url(#clipPath63)"
+         id="path219" />
+      <path
+         d="m 0,0 c 0,-0.062 -0.006,-0.123 -0.018,-0.186 -0.101,-0.542 -0.622,-0.9 -1.165,-0.798 -2.134,0.398 -2.619,2.855 -3.046,5.022 -0.303,1.543 -0.649,3.29 -1.449,3.441 -0.803,0.15 -1.757,-1.357 -2.599,-2.687 -1.182,-1.865 -2.519,-3.98 -4.655,-3.581 -2.136,0.398 -2.621,2.852 -3.049,5.02 -0.304,1.542 -0.65,3.292 -1.452,3.442 -0.805,0.151 -1.758,-1.357 -2.599,-2.686 -1.182,-1.865 -2.521,-3.98 -4.658,-3.581 -2.138,0.398 -2.624,2.854 -3.054,5.022 -0.304,1.543 -0.651,3.292 -1.458,3.444 -0.807,0.15 -1.761,-1.357 -2.603,-2.687 -1.183,-1.864 -2.523,-3.979 -4.661,-3.579 -0.545,0.102 -0.898,0.629 -0.799,1.166 0.102,0.543 0.623,0.9 1.166,0.799 0.806,-0.151 1.761,1.357 2.605,2.684 1.181,1.867 2.521,3.98 4.659,3.582 2.138,-0.399 2.624,-2.855 3.054,-5.023 0.304,-1.542 0.652,-3.292 1.459,-3.444 0.804,-0.15 1.757,1.357 2.599,2.687 1.181,1.864 2.521,3.98 4.657,3.581 2.136,-0.399 2.62,-2.853 3.048,-5.02 0.304,-1.543 0.65,-3.293 1.453,-3.443 0.802,-0.15 1.757,1.357 2.599,2.687 1.181,1.865 2.519,3.979 4.655,3.581 C -3.177,9.045 -2.695,6.59 -2.267,4.425 -1.962,2.88 -1.618,1.131 -0.816,0.98 -0.336,0.89 0,0.471 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1055.1012,453.87893)"
+         clip-path="url(#clipPath64)"
+         id="path220" />
+      <path
+         d="m 0,0 c 0,-0.051 -0.004,-0.1 -0.012,-0.15 -0.08,-0.545 -0.589,-0.922 -1.136,-0.84 -0.246,0.035 -0.912,-1.103 -1.164,-1.531 -0.712,-1.221 -1.601,-2.736 -3.185,-2.497 -1.583,0.238 -1.988,1.948 -2.31,3.323 -0.115,0.482 -0.416,1.767 -0.662,1.804 -0.244,0.037 -0.933,-1.142 -1.16,-1.531 -0.712,-1.218 -1.599,-2.735 -3.182,-2.497 -1.584,0.236 -1.984,1.949 -2.309,3.323 -0.101,0.438 -0.414,1.768 -0.656,1.804 -0.244,0.036 -0.933,-1.144 -1.16,-1.53 -0.712,-1.22 -1.599,-2.738 -3.183,-2.5 -1.581,0.239 -1.984,1.949 -2.305,3.324 -0.102,0.437 -0.412,1.767 -0.655,1.804 -0.548,0.082 -0.924,0.613 -0.84,1.136 0.083,0.547 0.592,0.922 1.137,0.84 1.582,-0.238 1.984,-1.949 2.306,-3.323 0.102,-0.438 0.412,-1.768 0.655,-1.804 0.243,-0.036 0.933,1.144 1.159,1.53 0.713,1.221 1.6,2.738 3.183,2.5 1.584,-0.239 1.984,-1.949 2.306,-3.324 0.104,-0.437 0.416,-1.767 0.658,-1.804 0.244,-0.037 0.934,1.142 1.16,1.531 0.713,1.219 1.599,2.736 3.183,2.498 1.583,-0.239 1.988,-1.949 2.31,-3.324 0.115,-0.482 0.416,-1.767 0.662,-1.804 0.246,-0.037 0.912,1.103 1.164,1.531 0.712,1.218 1.601,2.735 3.185,2.497 C -0.356,0.912 0,0.486 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,961.99787,497.6476)"
+         clip-path="url(#clipPath65)"
+         id="path221" />
+      <path
+         d="m 0,0 c 0,-2.371 -2.125,-4.702 -4.192,-6.973 -2.123,-2.328 -4.308,-4.726 -3.466,-6.485 0.25,-0.494 0.035,-1.095 -0.461,-1.336 -0.496,-0.242 -1.096,-0.035 -1.336,0.461 -1.447,2.972 1.213,5.886 3.784,8.707 2.121,2.328 4.31,4.733 3.466,6.487 -0.853,1.754 -4.102,1.515 -7.246,1.285 -3.806,-0.279 -7.744,-0.566 -9.187,2.404 -1.447,2.966 1.208,5.887 3.78,8.713 2.123,2.331 4.312,4.744 3.464,6.492 -0.853,1.754 -4.104,1.515 -7.246,1.287 -3.808,-0.279 -7.745,-0.566 -9.19,2.405 -1.442,2.973 1.211,5.9 3.777,8.721 2.121,2.334 4.302,4.745 3.46,6.503 -0.855,1.757 -4.106,1.523 -7.25,1.294 -3.81,-0.277 -7.746,-0.562 -9.193,2.414 -0.237,0.492 -0.037,1.095 0.46,1.335 0.496,0.243 1.096,0.036 1.336,-0.46 0.856,-1.758 4.106,-1.524 7.25,-1.295 3.81,0.277 7.747,0.562 9.194,-2.414 1.454,-2.969 -1.205,-5.893 -3.777,-8.722 -2.12,-2.332 -4.317,-4.747 -3.458,-6.501 0.851,-1.753 4.102,-1.515 7.244,-1.286 3.808,0.279 7.745,0.566 9.19,-2.406 1.446,-2.98 -1.213,-5.893 -3.781,-8.713 -2.12,-2.332 -4.309,-4.729 -3.464,-6.493 0.853,-1.753 4.103,-1.515 7.247,-1.285 3.805,0.28 7.744,0.567 9.187,-2.403 C -0.125,1.156 0,0.576 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,971.21973,1000.4119)"
+         clip-path="url(#clipPath66)"
+         id="path222" />
+      <path
+         d="m 0,0 c 0,-0.507 -0.387,-0.943 -0.904,-0.994 -0.549,-0.053 -1.037,0.35 -1.092,0.901 -0.232,2.403 -3.968,3.495 -7.58,4.549 -4.251,1.242 -8.647,2.525 -9.01,6.276 -0.332,3.767 3.708,5.854 7.645,7.885 3.345,1.728 6.85,3.493 6.569,5.915 -0.231,2.397 -3.966,3.487 -7.578,4.54 -4.251,1.237 -8.649,2.519 -9.01,6.268 -0.313,3.757 3.708,5.844 7.645,7.873 3.344,1.722 6.758,3.435 6.568,5.903 -0.23,2.398 -3.966,3.486 -7.578,4.538 -4.251,1.238 -8.647,2.519 -9.008,6.264 -0.33,3.724 3.708,5.839 7.645,7.865 3.343,1.721 6.799,3.505 6.571,5.898 -0.037,0.523 0.347,1.036 0.9,1.091 0.549,0.053 1.037,-0.35 1.091,-0.9 0.342,-3.736 -3.71,-5.84 -7.646,-7.868 -3.345,-1.722 -6.793,-3.534 -6.569,-5.895 0.23,-2.395 3.964,-3.483 7.577,-4.536 4.25,-1.237 8.648,-2.519 9.009,-6.266 0.363,-3.741 -3.706,-5.842 -7.645,-7.873 -3.345,-1.724 -6.762,-3.542 -6.568,-5.903 0.23,-2.4 3.965,-3.488 7.578,-4.54 4.251,-1.238 8.646,-2.521 9.009,-6.268 0.323,-3.743 -3.708,-5.852 -7.642,-7.883 -3.345,-1.726 -6.8,-3.452 -6.571,-5.916 C -16.363,8.52 -12.628,7.43 -9.016,6.376 -4.765,5.134 -0.367,3.851 -0.004,0.098 -0.002,0.067 0,0.033 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1246.6097,561.57587)"
+         clip-path="url(#clipPath67)"
+         id="path223" />
+      <path
+         d="m 0,0 c 0,-0.513 -0.395,-0.951 -0.916,-0.994 -0.648,-0.054 -1.119,-1.591 -1.497,-2.828 -0.584,-1.905 -1.245,-4.065 -3.24,-4.231 -2,-0.168 -3.009,1.855 -3.902,3.638 -0.575,1.154 -1.294,2.591 -1.94,2.538 -0.647,-0.054 -1.115,-1.591 -1.492,-2.825 -0.584,-1.906 -1.244,-4.068 -3.24,-4.232 -1.994,-0.168 -3.003,1.854 -3.892,3.636 -0.575,1.156 -1.292,2.591 -1.937,2.539 -0.646,-0.055 -1.115,-1.59 -1.491,-2.824 -0.582,-1.906 -1.242,-4.067 -3.236,-4.233 -1.994,-0.166 -3.001,1.855 -3.891,3.638 -0.575,1.154 -1.291,2.591 -1.934,2.538 -0.55,-0.047 -1.035,0.364 -1.08,0.912 -0.064,0.516 0.36,1.033 0.912,1.08 1.994,0.168 3.002,-1.855 3.892,-3.638 0.576,-1.154 1.291,-2.591 1.935,-2.539 0.644,0.055 1.113,1.592 1.49,2.826 0.582,1.906 1.242,4.068 3.237,4.232 1.994,0.168 3.004,-1.854 3.892,-3.636 0.576,-1.156 1.293,-2.591 1.937,-2.539 0.647,0.055 1.115,1.59 1.492,2.824 0.584,1.908 1.244,4.067 3.238,4.233 1.997,0.168 3.007,-1.853 3.897,-3.636 0.578,-1.156 1.297,-2.593 1.945,-2.54 0.648,0.054 1.117,1.591 1.496,2.825 0.583,1.906 1.244,4.068 3.241,4.234 0.551,0.047 1.035,-0.363 1.08,-0.912 C -0.002,0.056 0,0.029 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1260.7575,749.0324)"
+         clip-path="url(#clipPath68)"
+         id="path224" />
+      <path
+         d="m 0,0 c 0,-0.967 -0.219,-1.925 -0.709,-2.869 -2.451,-4.719 -9.117,-4.057 -15.565,-3.419 -5.787,0.573 -11.77,1.166 -13.598,-2.352 -1.83,-3.529 2.103,-8.065 5.901,-12.461 4.233,-4.905 8.613,-9.978 6.162,-14.69 -2.446,-4.713 -9.113,-4.047 -15.561,-3.405 -5.783,0.578 -11.762,1.174 -13.586,-2.336 -1.814,-3.497 2.107,-8.054 5.905,-12.458 4.233,-4.903 8.615,-9.976 6.162,-14.686 -2.444,-4.707 -9.109,-4.04 -15.555,-3.393 -5.781,0.579 -11.76,1.177 -13.58,-2.326 -0.254,-0.49 -0.858,-0.681 -1.348,-0.426 -0.492,0.256 -0.685,0.865 -0.426,1.348 2.445,4.708 9.11,4.04 15.556,3.394 5.781,-0.58 11.76,-1.178 13.58,2.325 1.822,3.515 -2.109,8.061 -5.903,12.458 -4.237,4.905 -8.615,9.978 -6.164,14.686 2.446,4.712 9.113,4.046 15.559,3.404 5.784,-0.576 11.765,-1.174 13.589,2.337 1.815,3.507 -2.104,8.063 -5.904,12.462 -4.231,4.903 -8.615,9.967 -6.16,14.688 2.451,4.72 9.119,4.06 15.568,3.421 5.784,-0.574 11.767,-1.166 13.595,2.351 1.824,3.525 -2.099,8.07 -5.895,12.474 -4.232,4.911 -8.598,9.992 -6.155,14.704 0.254,0.49 0.857,0.681 1.347,0.425 0.492,-0.253 0.686,-0.861 0.426,-1.347 -1.822,-3.513 2.095,-8.071 5.897,-12.476 C -3.478,7.907 -0.002,3.872 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,278.89733,-42.782933)"
+         clip-path="url(#clipPath69)"
+         id="path225" />
+      <path
+         d="m 0,0 c 0,-0.248 -0.092,-0.496 -0.276,-0.689 -0.38,-0.4 -1.013,-0.416 -1.413,-0.035 -0.238,0.08 -1.146,-0.336 -1.633,-0.559 -1.216,-0.556 -2.729,-1.25 -3.844,-0.187 -1.113,1.066 -0.496,2.609 0,3.849 0.199,0.498 0.57,1.425 0.47,1.669 C -6.928,4.116 -7.832,3.7 -8.32,3.478 -9.535,2.919 -11.046,2.226 -12.161,3.286 c -1.112,1.065 -0.493,2.607 0.002,3.849 0.199,0.498 0.562,1.416 0.472,1.67 -0.23,0.064 -1.136,-0.352 -1.622,-0.574 -1.215,-0.557 -2.729,-1.252 -3.843,-0.192 -1.111,1.06 -0.494,2.609 0.004,3.847 0.201,0.498 0.572,1.418 0.472,1.668 -0.398,0.384 -0.408,1.011 -0.029,1.408 0.381,0.398 1.019,0.408 1.417,0.027 1.115,-1.059 0.497,-2.605 -0.003,-3.847 -0.199,-0.496 -0.582,-1.423 -0.473,-1.667 0.228,-0.065 1.135,0.351 1.621,0.573 1.214,0.557 2.728,1.252 3.843,0.192 1.115,-1.059 0.495,-2.605 -0.002,-3.849 -0.202,-0.496 -0.553,-1.421 -0.473,-1.669 0.231,-0.065 1.136,0.349 1.623,0.574 1.214,0.556 2.727,1.252 3.843,0.189 1.117,-1.06 0.498,-2.606 0,-3.849 -0.2,-0.499 -0.578,-1.431 -0.471,-1.669 0.232,-0.07 1.138,0.346 1.627,0.568 1.214,0.557 2.727,1.25 3.843,0.19 C -0.104,0.527 0,0.264 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,886.30707,332.76373)"
+         clip-path="url(#clipPath70)"
+         id="path226" />
+      <path
+         d="m 0,0 c 0,-0.226 -0.076,-0.453 -0.23,-0.638 -3.292,-3.959 -9.457,-1.949 -15.418,-0.008 -5.328,1.736 -10.836,3.53 -13.261,0.615 -2.427,-2.912 0.334,-8.01 3.005,-12.936 2.99,-5.513 6.079,-11.207 2.787,-15.173 -3.299,-3.96 -9.463,-1.953 -15.427,-0.014 -5.329,1.734 -10.839,3.527 -13.268,0.608 -2.431,-2.919 0.33,-8.014 3.003,-12.941 2.988,-5.512 6.077,-11.208 2.785,-15.174 -3.302,-3.966 -9.471,-1.964 -15.436,-0.027 -5.333,1.73 -10.845,3.52 -13.28,0.593 -2.437,-2.923 0.326,-8.021 2.993,-12.952 2.99,-5.516 6.073,-11.212 2.775,-15.184 -0.354,-0.423 -0.984,-0.48 -1.41,-0.129 -0.42,0.358 -0.476,0.987 -0.129,1.41 2.445,2.923 -0.322,8.024 -2.993,12.952 -2.99,5.515 -6.071,11.218 -2.775,15.184 3.302,3.966 9.47,1.965 15.436,0.028 5.333,-1.73 10.845,-3.521 13.28,-0.594 2.431,2.913 -0.33,8.012 -3.003,12.938 -2.986,5.515 -6.081,11.211 -2.785,15.175 3.296,3.96 9.463,1.954 15.426,0.015 5.329,-1.734 10.84,-3.526 13.271,-0.607 2.423,2.91 -0.334,8.01 -3.007,12.937 -2.992,5.51 -6.083,11.204 -2.787,15.172 3.294,3.956 9.459,1.946 15.42,0.006 5.327,-1.736 10.836,-3.531 13.259,-0.617 0.353,0.425 0.984,0.482 1.408,0.13 C -0.123,0.57 0,0.287 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,428.71147,712.2052)"
+         clip-path="url(#clipPath71)"
+         id="path227" />
+      <path
+         d="m 0,0 v -0.049 c -0.033,-1.568 -1.631,-2.169 -2.915,-2.652 -0.495,-0.185 -1.52,-0.572 -1.623,-0.824 0.093,-0.251 1.103,-0.679 1.587,-0.884 1.252,-0.529 2.806,-1.187 2.806,-2.722 v -0.045 c -0.033,-1.568 -1.632,-2.169 -2.917,-2.652 -0.492,-0.183 -1.515,-0.568 -1.621,-0.822 0.094,-0.25 1.103,-0.675 1.588,-0.881 1.249,-0.529 2.804,-1.187 2.804,-2.72 V -14.3 c -0.031,-1.566 -1.631,-2.165 -2.915,-2.647 -0.492,-0.184 -1.514,-0.569 -1.621,-0.821 -0.01,-0.55 -0.467,-0.987 -1.018,-0.978 -0.552,0.012 -0.931,0.438 -0.98,1.022 0.031,1.568 1.631,2.167 2.915,2.649 0.493,0.184 1.514,0.569 1.621,0.82 -0.095,0.252 -1.101,0.678 -1.585,0.881 -1.264,0.533 -2.75,1.244 -2.806,2.767 0.033,1.568 1.632,2.169 2.917,2.652 0.492,0.183 1.515,0.568 1.621,0.822 -0.094,0.25 -1.104,0.677 -1.588,0.882 -1.265,0.535 -2.894,1.291 -2.806,2.767 0.033,1.57 1.631,2.172 2.916,2.654 0.493,0.186 1.519,0.572 1.622,0.824 -0.094,0.256 -1.101,0.681 -1.587,0.889 -1.25,0.529 -2.804,1.187 -2.804,2.722 v 0.049 c 0.011,0.55 0.468,0.989 1.021,0.978 0.545,-0.012 0.978,-0.457 0.978,-1 V 3.61 C -4.298,3.355 -3.29,2.929 -2.804,2.722 -1.554,2.193 0,1.535 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1173.9364,320.9328)"
+         clip-path="url(#clipPath72)"
+         id="path228" />
+      <path
+         d="m 0,0 c 0,-0.1 -0.014,-0.199 -0.045,-0.299 -0.576,-1.835 -2.72,-1.997 -4.61,-2.14 -1.133,-0.086 -2.681,-0.201 -2.851,-0.744 -0.188,-0.539 1.035,-1.527 1.913,-2.245 1.469,-1.197 3.146,-2.553 2.559,-4.39 -0.575,-1.837 -2.719,-2.001 -4.609,-2.144 -1.133,-0.086 -2.683,-0.203 -2.853,-0.748 -0.195,-0.543 1.033,-1.527 1.914,-2.245 1.47,-1.197 3.138,-2.557 2.56,-4.392 -0.578,-1.839 -2.72,-2.003 -4.612,-2.148 -1.133,-0.086 -2.685,-0.205 -2.855,-0.751 -0.199,-0.54 1.033,-1.532 1.913,-2.25 1.469,-1.197 3.146,-2.554 2.556,-4.396 -0.163,-0.527 -0.726,-0.82 -1.251,-0.654 -0.527,0.164 -0.824,0.727 -0.654,1.252 0.144,0.562 -1.033,1.531 -1.916,2.249 -1.469,1.197 -3.14,2.558 -2.556,4.396 0.576,1.839 2.718,2.003 4.61,2.148 1.133,0.086 2.685,0.205 2.855,0.752 0.178,0.519 -1.033,1.525 -1.913,2.245 -1.469,1.197 -3.142,2.554 -2.559,4.392 0.575,1.837 2.719,2.001 4.609,2.144 1.133,0.085 2.683,0.203 2.853,0.748 0.172,0.54 -1.031,1.525 -1.914,2.241 -1.468,1.199 -3.146,2.564 -2.558,4.394 0.574,1.835 2.718,1.998 4.608,2.14 1.133,0.086 2.681,0.201 2.851,0.744 0.166,0.527 0.726,0.82 1.254,0.656 C -0.274,0.82 0,0.426 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,394.514,847.7548)"
+         clip-path="url(#clipPath73)"
+         id="path229" />
+      <path
+         d="m 0,0 c 0,-1.512 -0.449,-3.232 -0.892,-4.923 -0.686,-2.622 -1.398,-5.338 -0.094,-6.297 0.445,-0.324 0.543,-0.953 0.211,-1.398 -0.328,-0.443 -0.953,-0.539 -1.398,-0.211 -2.392,1.763 -1.51,5.141 -0.652,8.412 0.685,2.624 1.398,5.337 0.093,6.295 -1.302,0.959 -3.684,-0.521 -5.986,-1.954 -2.871,-1.785 -5.839,-3.63 -8.233,-1.865 -2.396,1.763 -1.51,5.143 -0.656,8.414 0.683,2.626 1.396,5.341 0.09,6.299 -1.303,0.961 -3.687,-0.521 -5.991,-1.952 -2.87,-1.785 -5.836,-3.628 -8.233,-1.865 -2.394,1.763 -1.515,5.143 -0.664,8.418 0.686,2.626 1.395,5.341 0.084,6.305 -1.306,0.963 -3.69,-0.517 -5.996,-1.949 -2.873,-1.782 -5.84,-3.624 -8.239,-1.859 -0.443,0.329 -0.538,0.955 -0.21,1.398 0.326,0.444 0.953,0.539 1.398,0.211 1.306,-0.963 3.69,0.518 5.996,1.949 2.871,1.783 5.841,3.626 8.239,1.859 2.398,-1.763 1.515,-5.145 0.664,-8.418 -0.684,-2.626 -1.392,-5.338 -0.084,-6.305 1.302,-0.961 3.686,0.521 5.991,1.953 2.87,1.784 5.836,3.628 8.232,1.865 2.394,-1.766 1.507,-5.148 0.656,-8.415 -0.683,-2.626 -1.396,-5.336 -0.09,-6.299 1.303,-0.961 3.685,0.521 5.989,1.954 2.869,1.783 5.837,3.629 8.231,1.865 C -0.39,2.638 0,1.41 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,571.6552,38.169733)"
+         clip-path="url(#clipPath74)"
+         id="path230" />
+      <path
+         d="m 0,0 c 0,-1.867 -1.541,-3.778 -2.937,-5.512 -1.464,-1.824 -2.988,-3.709 -2.327,-4.87 0.269,-0.485 0.099,-1.092 -0.38,-1.363 -0.482,-0.272 -1.091,-0.102 -1.362,0.378 -1.321,2.359 0.716,4.878 2.513,7.108 1.464,1.822 2.972,3.702 2.327,4.87 -0.656,1.166 -3.056,0.842 -5.376,0.53 -2.838,-0.385 -6.059,-0.819 -7.383,1.524 -1.327,2.347 0.713,4.878 2.51,7.114 1.464,1.82 2.991,3.694 2.327,4.876 -0.658,1.164 -3.055,0.839 -5.375,0.527 -2.842,-0.383 -6.063,-0.816 -7.385,1.531 -1.326,2.349 0.712,4.884 2.505,7.116 1.467,1.822 2.987,3.698 2.324,4.879 -0.66,1.17 -3.06,0.848 -5.38,0.537 -2.843,-0.382 -6.063,-0.814 -7.389,1.533 -0.269,0.478 -0.101,1.092 0.379,1.363 0.48,0.272 1.091,0.102 1.363,-0.379 0.66,-1.169 3.06,-0.847 5.379,-0.537 2.843,0.383 6.063,0.814 7.39,-1.533 1.325,-2.356 -0.71,-4.881 -2.506,-7.115 -1.468,-1.826 -2.984,-3.718 -2.324,-4.882 0.658,-1.168 3.056,-0.843 5.376,-0.531 2.841,0.383 6.061,0.818 7.385,-1.527 1.322,-2.347 -0.715,-4.878 -2.511,-7.112 -1.469,-1.825 -2.986,-3.719 -2.326,-4.875 0.656,-1.166 3.056,-0.842 5.376,-0.529 2.839,0.384 6.059,0.818 7.383,-1.526 C -0.129,1.07 0,0.537 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,719.74907,587.29627)"
+         clip-path="url(#clipPath75)"
+         id="path231" />
+      <path
+         d="m 0,0 c 0,-0.119 -0.022,-0.238 -0.064,-0.355 -0.858,-2.254 -3.703,-2.299 -6.214,-2.34 -1.97,-0.031 -4.005,-0.064 -4.38,-1.052 -0.383,-0.975 1.123,-2.365 2.574,-3.696 1.853,-1.701 3.944,-3.627 3.093,-5.88 -0.857,-2.255 -3.705,-2.302 -6.218,-2.345 -1.968,-0.034 -4.004,-0.067 -4.379,-1.055 -0.379,-1.003 1.124,-2.366 2.573,-3.698 1.852,-1.699 3.941,-3.622 3.093,-5.882 -0.859,-2.257 -3.706,-2.306 -6.219,-2.349 -1.968,-0.033 -4.005,-0.068 -4.382,-1.062 -0.392,-0.99 1.121,-2.372 2.572,-3.704 1.849,-1.697 3.946,-3.615 3.089,-5.885 -0.197,-0.516 -0.773,-0.776 -1.291,-0.581 -0.513,0.198 -0.765,0.778 -0.58,1.291 0.379,0.996 -1.123,2.371 -2.571,3.703 -1.852,1.702 -3.927,3.632 -3.089,5.887 0.857,2.259 3.706,2.308 6.219,2.351 1.968,0.033 4.005,0.068 4.381,1.06 0.393,0.998 -1.122,2.365 -2.573,3.699 -1.853,1.696 -3.939,3.61 -3.093,5.881 0.859,2.255 3.706,2.302 6.217,2.343 1.969,0.033 4.005,0.067 4.38,1.057 0.381,0.978 -1.123,2.362 -2.573,3.696 -1.854,1.699 -3.947,3.63 -3.093,5.88 0.857,2.253 3.706,2.3 6.217,2.341 1.968,0.031 4.003,0.064 4.376,1.051 0.197,0.515 0.773,0.775 1.29,0.579 C -0.246,0.783 0,0.402 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1078.4245,586.2704)"
+         clip-path="url(#clipPath76)"
+         id="path232" />
+      <path
+         d="m 0,0 c 0.002,-2.425 -2.575,-4.052 -5.075,-5.63 -2.16,-1.358 -4.366,-2.727 -4.116,-4.237 0.092,-0.535 -0.256,-1.064 -0.801,-1.164 -0.543,-0.101 -1.064,0.258 -1.164,0.801 -0.521,2.787 2.291,4.575 5.013,6.294 2.158,1.359 4.352,2.743 4.116,4.237 -0.273,1.47 -2.861,1.984 -5.364,2.48 -3.155,0.627 -6.418,1.275 -6.938,4.079 -0.523,2.771 2.289,4.577 5.011,6.295 2.158,1.363 4.386,2.757 4.116,4.243 -0.273,1.473 -2.861,1.988 -5.364,2.484 -3.156,0.627 -6.421,1.276 -6.94,4.079 -0.527,2.818 2.291,4.587 5.011,6.308 2.157,1.363 4.386,2.788 4.114,4.249 -0.275,1.478 -2.862,1.993 -5.366,2.491 -3.156,0.629 -6.418,1.279 -6.94,4.085 -0.097,0.539 0.258,1.066 0.799,1.166 0.543,0.101 1.066,-0.256 1.166,-0.799 0.275,-1.476 2.862,-1.991 5.366,-2.49 3.155,-0.628 6.42,-1.278 6.939,-4.088 0.526,-2.787 -2.288,-4.581 -5.008,-6.304 -2.158,-1.364 -4.353,-2.753 -4.116,-4.253 0.273,-1.47 2.862,-1.985 5.366,-2.481 3.155,-0.627 6.418,-1.275 6.937,-4.081 0.535,-2.775 -2.288,-4.577 -5.012,-6.3 -2.156,-1.361 -4.39,-2.788 -4.114,-4.239 C -12.091,5.753 -9.504,5.239 -7,4.743 -3.845,4.116 -0.582,3.468 -0.062,0.664 -0.02,0.437 0,0.215 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,819.18707,1096.4501)"
+         clip-path="url(#clipPath77)"
+         id="path233" />
+      <path
+         d="m 0,0 v -0.033 c -0.17,-5.241 -6.391,-7.49 -12.409,-9.668 -5.39,-1.949 -10.962,-3.966 -11.088,-7.852 -0.093,-3.803 5.308,-6.264 10.563,-8.56 5.783,-2.527 11.761,-5.138 11.763,-10.242 0,-0.07 -0.002,-0.143 -0.004,-0.215 -0.168,-5.246 -6.392,-7.5 -12.408,-9.679 -5.389,-1.953 -10.964,-3.972 -11.089,-7.865 -0.106,-3.884 5.307,-6.265 10.562,-8.563 5.864,-2.562 11.968,-5.155 11.759,-10.461 -0.168,-5.254 -6.391,-7.513 -12.407,-9.697 -5.391,-1.956 -10.965,-3.979 -11.09,-7.879 -0.001,-0.044 -0.001,-0.09 -0.001,-0.132 0,-3.825 5.367,-6.175 10.562,-8.446 5.864,-2.565 11.901,-5.311 11.759,-10.474 -0.018,-0.552 -0.481,-0.986 -1.031,-0.968 -0.551,0.019 -1.002,0.496 -0.969,1.031 0.074,3.968 -5.309,6.282 -10.56,8.578 -5.864,2.566 -11.923,5.305 -11.759,10.474 0.168,5.255 6.389,7.514 12.405,9.697 5.391,1.957 10.967,3.98 11.091,7.881 0.002,0.045 0.002,0.09 0.002,0.133 0,3.815 -5.368,6.163 -10.562,8.431 -5.785,2.527 -11.763,5.14 -11.763,10.248 0,0.07 0,0.141 0.002,0.211 0.17,5.249 6.391,7.502 12.408,9.681 5.391,1.953 10.964,3.972 11.089,7.864 0.063,4.001 -5.307,6.266 -10.56,8.558 -5.864,2.562 -11.892,5.306 -11.761,10.457 0.168,5.243 6.391,7.492 12.407,9.669 C -7.697,-5.87 -2.124,-3.855 -2,0.033 -1.982,0.584 -1.519,1.017 -0.967,1 -0.426,0.982 0,0.537 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1260.2573,-53.290933)"
+         clip-path="url(#clipPath78)"
+         id="path234" />
+      <path
+         d="m 0,0 c 0,-0.435 -0.285,-0.836 -0.725,-0.961 -2.405,-0.691 -2.807,-4.682 -3.198,-8.54 -0.455,-4.525 -0.927,-9.202 -4.637,-10.266 -3.707,-1.064 -6.589,2.648 -9.375,6.239 -2.379,3.066 -4.837,6.235 -7.245,5.543 -2.4,-0.689 -2.802,-4.68 -3.189,-8.54 -0.453,-4.521 -0.923,-9.195 -4.625,-10.26 -3.703,-1.064 -6.581,2.65 -9.365,6.243 -2.377,3.066 -4.833,6.235 -7.235,5.545 -2.398,-0.689 -2.798,-4.678 -3.185,-8.538 -0.453,-4.523 -0.921,-9.197 -4.624,-10.262 -3.698,-1.062 -6.575,2.654 -9.357,6.247 -2.374,3.066 -4.829,6.237 -7.227,5.547 -0.529,-0.152 -1.084,0.155 -1.236,0.686 -0.162,0.523 0.152,1.084 0.685,1.236 3.699,1.062 6.577,-2.652 9.359,-6.245 2.373,-3.068 4.828,-6.237 7.226,-5.549 2.397,0.689 2.798,4.68 3.184,8.539 0.453,4.522 0.922,9.199 4.624,10.261 3.702,1.064 6.581,-2.65 9.365,-6.243 2.377,-3.065 4.833,-6.235 7.235,-5.545 2.4,0.689 2.8,4.68 3.187,8.539 0.454,4.522 0.923,9.197 4.628,10.261 3.706,1.064 6.588,-2.648 9.374,-6.239 2.379,-3.065 4.837,-6.234 7.245,-5.544 2.407,0.692 2.81,4.683 3.2,8.544 0.455,4.522 0.928,9.199 4.636,10.263 0.529,0.152 1.083,-0.154 1.236,-0.685 C -0.012,0.184 0,0.092 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,557.6744,419.00693)"
+         clip-path="url(#clipPath79)"
+         id="path235" />
+      <path
+         d="m 0,0 c 0,-0.27 -0.108,-0.537 -0.32,-0.734 -2.738,-2.533 -6.831,-0.58 -10.787,1.308 -3.354,1.602 -6.824,3.257 -8.566,1.646 -1.746,-1.611 -0.369,-5.204 0.967,-8.675 1.571,-4.097 3.192,-8.33 0.46,-10.859 -2.741,-2.533 -6.834,-0.582 -10.792,1.304 -3.359,1.599 -6.831,3.255 -8.575,1.64 -1.745,-1.614 -0.367,-5.203 0.967,-8.676 1.572,-4.096 3.198,-8.328 0.459,-10.862 -2.744,-2.537 -6.838,-0.588 -10.8,1.296 -3.359,1.6 -6.833,3.252 -8.582,1.633 -1.756,-1.619 -0.373,-5.21 0.958,-8.683 1.568,-4.092 3.193,-8.331 0.451,-10.867 -0.405,-0.375 -1.038,-0.35 -1.413,0.054 -0.373,0.411 -0.348,1.041 0.055,1.414 1.755,1.621 0.374,5.21 -0.959,8.683 -1.57,4.092 -3.197,8.327 -0.451,10.867 2.743,2.539 6.84,0.59 10.8,-1.296 3.361,-1.598 6.834,-3.252 8.582,-1.633 1.744,1.609 0.367,5.206 -0.967,8.676 -1.571,4.097 -3.2,8.33 -0.458,10.863 2.741,2.533 6.834,0.582 10.792,-1.305 3.359,-1.599 6.83,-3.255 8.574,-1.64 1.744,1.607 0.365,5.202 -0.968,8.674 -1.57,4.091 -3.201,8.328 -0.459,10.861 2.737,2.532 6.83,0.58 10.786,-1.309 3.355,-1.601 6.825,-3.257 8.567,-1.646 0.406,0.375 1.038,0.35 1.413,-0.055 C -0.088,0.486 0,0.242 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,811.3216,621.4708)"
+         clip-path="url(#clipPath80)"
+         id="path236" />
+      <path
+         d="m 0,0 c 0,-0.226 -0.076,-0.453 -0.232,-0.641 -1.91,-2.292 -5.249,-1.202 -8.481,-0.15 -2.597,0.848 -5.282,1.724 -6.326,0.471 -1.049,-1.256 0.302,-3.737 1.604,-6.139 1.615,-2.992 3.291,-6.081 1.383,-8.376 -1.914,-2.294 -5.254,-1.206 -8.486,-0.154 -2.599,0.848 -5.284,1.722 -6.331,0.467 -1.043,-1.254 0.299,-3.737 1.603,-6.141 1.619,-2.99 3.295,-6.077 1.379,-8.375 -1.914,-2.298 -5.257,-1.213 -8.488,-0.162 -2.601,0.845 -5.288,1.718 -6.339,0.459 -1.04,-1.252 0.299,-3.746 1.599,-6.147 1.617,-2.99 3.291,-6.081 1.375,-8.381 -0.351,-0.424 -0.982,-0.48 -1.408,-0.127 -0.423,0.355 -0.478,0.986 -0.127,1.408 1.043,1.255 -0.298,3.743 -1.599,6.147 -1.619,2.989 -3.29,6.082 -1.374,8.381 1.915,2.298 5.258,1.212 8.49,0.161 2.599,-0.845 5.288,-1.718 6.336,-0.458 1.045,1.254 -0.3,3.737 -1.603,6.141 -1.619,2.992 -3.292,6.084 -1.378,8.375 1.911,2.294 5.252,1.207 8.484,0.154 2.599,-0.847 5.284,-1.722 6.331,-0.467 1.046,1.26 -0.303,3.742 -1.606,6.142 -1.618,2.987 -3.296,6.078 -1.38,8.373 1.909,2.292 5.251,1.203 8.482,0.15 2.597,-0.847 5.282,-1.724 6.325,-0.47 0.351,0.423 0.982,0.48 1.408,0.126 C -0.123,0.57 0,0.285 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1088.8124,926.03867)"
+         clip-path="url(#clipPath81)"
+         id="path237" />
+      <path
+         d="m 0,0 c 0,-0.736 -0.18,-1.459 -0.595,-2.167 -1.801,-3.064 -6.036,-2.42 -10.135,-1.795 -3.438,0.523 -6.994,1.064 -8.109,-0.832 -1.107,-1.896 1.089,-4.735 3.224,-7.482 2.536,-3.277 5.172,-6.661 3.364,-9.721 -1.797,-3.06 -6.032,-2.413 -10.127,-1.787 -3.438,0.526 -6.994,1.068 -8.107,-0.824 -1.107,-1.892 1.095,-4.733 3.226,-7.48 2.54,-3.273 5.172,-6.655 3.366,-9.719 -1.794,-3.058 -6.03,-2.409 -10.124,-1.781 -3.437,0.527 -6.991,1.072 -8.102,-0.816 -0.279,-0.477 -0.892,-0.637 -1.367,-0.355 -0.48,0.281 -0.633,0.9 -0.355,1.366 1.796,3.059 6.032,2.41 10.126,1.781 3.437,-0.527 6.989,-1.071 8.1,0.817 1.113,1.901 -1.096,4.735 -3.224,7.48 -2.54,3.275 -5.165,6.667 -3.368,9.719 1.798,3.061 6.033,2.415 10.13,1.789 3.437,-0.526 6.991,-1.069 8.104,0.821 1.105,1.897 -1.092,4.736 -3.224,7.483 -2.534,3.275 -5.169,6.659 -3.365,9.721 1.801,3.065 6.036,2.421 10.135,1.796 3.439,-0.523 6.994,-1.064 8.11,0.832 1.12,1.91 -1.09,4.743 -3.221,7.493 -2.538,3.276 -5.162,6.67 -3.36,9.726 0.279,0.476 0.892,0.636 1.367,0.355 0.48,-0.279 0.632,-0.898 0.355,-1.367 -1.111,-1.908 1.09,-4.741 3.22,-7.49 C -2.003,5.042 0,2.455 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,243.46507,536.37293)"
+         clip-path="url(#clipPath82)"
+         id="path238" />
+      <path
+         d="m 0,0 c 0,-0.326 -0.16,-0.648 -0.457,-0.84 -3.189,-2.062 -6.961,0.617 -10.611,3.208 -3.107,2.205 -6.319,4.486 -8.369,3.158 -2.05,-1.326 -1.291,-5.192 -0.553,-8.93 0.866,-4.389 1.765,-8.931 -1.429,-10.997 -3.191,-2.064 -6.967,0.613 -10.619,3.202 -3.106,2.205 -6.32,4.484 -8.373,3.156 -2.056,-1.33 -1.291,-5.196 -0.556,-8.934 0.867,-4.391 1.757,-8.933 -1.432,-10.997 -3.194,-2.068 -6.972,0.609 -10.626,3.196 -3.11,2.203 -6.325,4.48 -8.385,3.148 -2.056,-1.33 -1.3,-5.198 -0.564,-8.939 0.865,-4.392 1.755,-8.936 -1.439,-11.002 -0.463,-0.299 -1.082,-0.166 -1.383,0.297 -0.301,0.461 -0.169,1.082 0.297,1.383 2.062,1.333 1.301,5.201 0.563,8.935 -0.86,4.397 -1.754,8.937 1.44,11.005 3.195,2.068 6.974,-0.609 10.627,-3.196 3.111,-2.203 6.325,-4.48 8.385,-3.148 2.054,1.33 1.291,5.196 0.556,8.934 -0.869,4.387 -1.761,8.931 1.432,10.997 3.19,2.064 6.965,-0.613 10.614,-3.202 3.109,-2.205 6.323,-4.486 8.377,-3.156 2.051,1.326 1.291,5.192 0.553,8.93 -0.863,4.393 -1.761,8.933 1.429,10.997 3.189,2.064 6.964,-0.617 10.613,-3.206 3.105,-2.207 6.317,-4.485 8.367,-3.16 C -1.08,1.138 -0.461,1.005 -0.16,0.543 -0.051,0.375 0,0.187 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,216.042,707.2136)"
+         clip-path="url(#clipPath83)"
+         id="path239" />
+      <path
+         d="m 0,0 c 0,-0.388 -0.229,-0.759 -0.611,-0.921 -3.589,-1.516 -3.468,-7.423 -3.357,-13.158 0.131,-6.389 0.258,-12.995 -4.579,-15.041 -4.835,-2.044 -9.484,2.652 -13.979,7.193 -4.027,4.068 -8.192,8.274 -11.781,6.757 -3.579,-1.515 -3.46,-7.438 -3.343,-13.151 0.139,-6.389 0.266,-12.992 -4.565,-15.036 -4.827,-2.041 -9.472,2.658 -13.964,7.199 -4.024,4.07 -8.183,8.278 -11.765,6.763 -3.577,-1.514 -3.456,-7.421 -3.338,-13.15 0.132,-6.395 0.265,-12.995 -4.564,-15.035 -4.821,-2.039 -9.463,2.661 -13.952,7.205 -4.02,4.069 -8.178,8.277 -11.753,6.766 -0.508,-0.215 -1.093,0.023 -1.31,0.533 -0.207,0.504 0.019,1.094 0.533,1.31 4.821,2.039 9.463,-2.661 13.952,-7.205 4.02,-4.069 8.178,-8.277 11.753,-6.766 3.581,1.513 3.466,7.438 3.341,13.151 -0.131,6.392 -0.267,12.992 4.561,15.034 4.827,2.04 9.473,-2.658 13.964,-7.2 4.024,-4.069 8.184,-8.277 11.765,-6.762 3.579,1.514 3.464,7.428 3.343,13.152 -0.129,6.389 -0.264,12.993 4.565,15.035 4.835,2.045 9.484,-2.652 13.979,-7.193 4.027,-4.068 8.192,-8.274 11.781,-6.757 3.589,1.517 3.472,7.438 3.357,13.159 -0.124,6.395 -0.258,12.991 4.579,15.04 0.507,0.215 1.093,-0.023 1.31,-0.533 C -0.026,0.262 0,0.131 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,323.08773,941.97787)"
+         clip-path="url(#clipPath84)"
+         id="path240" />
+      <path
+         d="m 0,0 c 0,-0.041 -0.002,-0.08 -0.008,-0.119 -0.064,-0.549 -0.562,-0.941 -1.109,-0.875 -5.614,0.666 -7.465,7.598 -9.256,14.301 -1.619,6.062 -3.294,12.328 -7.558,12.835 -4.273,0.506 -7.372,-5.194 -10.367,-10.706 C -31.612,9.338 -35.037,3.032 -40.655,3.7 c -5.618,0.666 -7.473,7.598 -9.267,14.302 -1.623,6.061 -3.3,12.329 -7.573,12.836 -4.274,0.508 -7.373,-5.192 -10.368,-10.704 -3.316,-6.098 -6.743,-12.403 -12.363,-11.736 -5.627,0.668 -7.486,7.6 -9.285,14.304 -1.626,6.063 -3.308,12.331 -7.59,12.841 -4.284,0.507 -7.385,-5.192 -10.386,-10.705 -3.318,-6.098 -6.75,-12.401 -12.376,-11.734 -0.551,0.065 -0.932,0.614 -0.875,1.109 0.065,0.549 0.562,0.941 1.109,0.875 4.284,-0.507 7.385,5.192 10.387,10.705 3.317,6.098 6.75,12.401 12.375,11.733 5.628,-0.667 7.489,-7.601 9.288,-14.305 1.626,-6.061 3.307,-12.329 7.587,-12.839 4.275,-0.508 7.376,5.194 10.371,10.707 3.316,6.096 6.743,12.401 12.361,11.733 5.619,-0.665 7.475,-7.597 9.269,-14.303 1.623,-6.061 3.3,-12.327 7.571,-12.835 4.272,-0.506 7.371,5.194 10.366,10.707 3.314,6.098 6.739,12.403 12.357,11.735 5.614,-0.666 7.465,-7.598 9.255,-14.301 C -6.823,7.764 -5.147,1.498 -0.883,0.99 -0.373,0.929 0,0.498 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,791.998,783.53747)"
+         clip-path="url(#clipPath85)"
+         id="path241" />
+      <path
+         d="m 0,0 c 0,-0.045 -0.002,-0.088 -0.008,-0.133 -0.072,-0.546 -0.574,-0.931 -1.123,-0.861 -3.706,0.486 -4.827,4.895 -5.911,9.16 -0.919,3.618 -1.87,7.36 -4.235,7.67 -2.367,0.311 -4.251,-3.058 -6.075,-6.317 -2.148,-3.841 -4.368,-7.812 -8.08,-7.326 -3.712,0.486 -4.835,4.897 -5.92,9.162 -0.92,3.618 -1.873,7.359 -4.241,7.67 -2.367,0.311 -4.253,-3.058 -6.077,-6.317 -2.148,-3.841 -4.37,-7.813 -8.083,-7.326 -3.717,0.488 -4.842,4.897 -5.932,9.161 -0.923,3.619 -1.878,7.362 -4.252,7.673 -2.375,0.312 -4.263,-3.058 -6.089,-6.317 -2.15,-3.839 -4.374,-7.809 -8.092,-7.323 -0.546,0.072 -0.926,0.582 -0.861,1.123 0.072,0.547 0.574,0.931 1.123,0.861 2.372,-0.312 4.26,3.058 6.086,6.315 2.15,3.841 4.376,7.81 8.094,7.325 3.716,-0.489 4.841,-4.898 5.93,-9.163 0.924,-3.618 1.879,-7.361 4.253,-7.672 2.369,-0.31 4.255,3.06 6.079,6.319 2.148,3.839 4.37,7.811 8.082,7.325 3.71,-0.489 4.833,-4.898 5.919,-9.16 0.92,-3.62 1.872,-7.362 4.243,-7.672 2.366,-0.311 4.251,3.058 6.075,6.317 2.148,3.841 4.368,7.812 8.08,7.326 3.708,-0.488 4.829,-4.897 5.913,-9.162 C -4.183,5.04 -3.234,1.298 -0.869,0.99 -0.367,0.924 0,0.494 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,717.64027,65.124533)"
+         clip-path="url(#clipPath86)"
+         id="path242" />
+      <path
+         d="m 0,0 c 0,-0.07 -0.008,-0.143 -0.024,-0.215 -0.119,-0.539 -0.652,-0.881 -1.191,-0.762 -0.968,0.213 -2.111,-1.464 -3.118,-2.942 -1.363,-2.006 -2.91,-4.277 -5.198,-3.771 -2.291,0.506 -2.738,3.218 -3.13,5.61 -0.291,1.765 -0.619,3.767 -1.59,3.982 -0.964,0.213 -2.105,-1.463 -3.11,-2.943 -1.363,-2.003 -2.908,-4.276 -5.195,-3.771 -2.288,0.506 -2.731,3.216 -3.124,5.609 -0.289,1.765 -0.615,3.766 -1.579,3.979 -0.967,0.213 -2.107,-1.464 -3.113,-2.944 -1.361,-2.004 -2.906,-4.277 -5.192,-3.771 -2.287,0.506 -2.73,3.218 -3.121,5.61 -0.286,1.763 -0.613,3.764 -1.577,3.977 -0.535,0.121 -0.869,0.643 -0.76,1.194 0.119,0.539 0.652,0.878 1.193,0.759 2.285,-0.505 2.728,-3.218 3.119,-5.61 0.287,-1.763 0.613,-3.765 1.577,-3.977 0.963,-0.214 2.103,1.462 3.107,2.942 1.363,2.006 2.907,4.278 5.196,3.773 2.289,-0.506 2.732,-3.216 3.124,-5.608 0.289,-1.766 0.616,-3.767 1.58,-3.98 0.967,-0.213 2.107,1.463 3.113,2.943 1.363,2.003 2.907,4.276 5.194,3.77 2.29,-0.505 2.738,-3.218 3.13,-5.61 0.291,-1.765 0.619,-3.766 1.589,-3.981 0.967,-0.213 2.107,1.462 3.115,2.942 1.363,2.004 2.909,4.277 5.2,3.771 C -0.318,0.873 0,0.461 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,881.3552,128.2556)"
+         clip-path="url(#clipPath87)"
+         id="path243" />
+      <path
+         d="m 0,0 c 0,-0.473 -0.338,-0.893 -0.818,-0.982 -2.093,-0.383 -2.784,-3.812 -3.452,-7.128 -0.801,-3.968 -1.627,-8.07 -5.052,-8.699 -3.425,-0.626 -5.653,2.915 -7.809,6.343 -1.802,2.86 -3.663,5.82 -5.756,5.436 -2.088,-0.383 -2.777,-3.81 -3.443,-7.124 -0.799,-3.967 -1.622,-8.07 -5.044,-8.699 -3.419,-0.626 -5.645,2.918 -7.799,6.344 -1.798,2.863 -3.657,5.821 -5.744,5.439 -2.086,-0.383 -2.775,-3.81 -3.441,-7.124 -0.797,-3.967 -1.621,-8.07 -5.04,-8.697 -3.417,-0.627 -5.641,2.917 -7.793,6.344 -1.796,2.863 -3.655,5.823 -5.739,5.44 -0.542,-0.099 -1.064,0.262 -1.164,0.805 -0.095,0.527 0.262,1.062 0.805,1.164 3.417,0.625 5.641,-2.92 7.791,-6.344 1.798,-2.863 3.656,-5.823 5.741,-5.441 2.085,0.381 2.773,3.808 3.439,7.122 0.796,3.968 1.62,8.072 5.042,8.699 3.418,0.627 5.645,-2.917 7.799,-6.344 1.798,-2.863 3.657,-5.821 5.744,-5.438 2.088,0.382 2.777,3.809 3.443,7.125 0.798,3.968 1.623,8.07 5.044,8.697 3.423,0.627 5.65,-2.915 7.806,-6.34 1.803,-2.863 3.666,-5.823 5.759,-5.439 2.091,0.383 2.782,3.812 3.45,7.126 0.801,3.967 1.627,8.07 5.05,8.701 0.545,0.099 1.064,-0.26 1.165,-0.802 C -0.006,0.121 0,0.06 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,347.6416,640.98427)"
+         clip-path="url(#clipPath88)"
+         id="path244" />
+      <path
+         d="m 0,0 c 0,-0.19 -0.053,-0.379 -0.164,-0.549 -0.303,-0.461 -0.922,-0.59 -1.384,-0.287 -2.311,1.515 -1.637,4.8 -1.051,7.694 0.486,2.384 0.988,4.848 -0.188,5.624 -1.177,0.771 -3.239,-0.674 -5.233,-2.07 -2.421,-1.697 -5.167,-3.621 -7.478,-2.105 -2.312,1.517 -1.642,4.801 -1.057,7.697 0.486,2.382 0.986,4.852 -0.191,5.626 -1.179,0.773 -3.242,-0.672 -5.235,-2.068 -2.424,-1.697 -5.169,-3.618 -7.481,-2.103 -2.31,1.517 -1.648,4.799 -1.06,7.699 0.48,2.386 0.986,4.855 -0.199,5.63 -1.182,0.775 -3.246,-0.67 -5.243,-2.066 -2.422,-1.695 -5.169,-3.615 -7.483,-2.097 -0.465,0.302 -0.592,0.919 -0.287,1.384 0.302,0.461 0.921,0.59 1.384,0.287 1.181,-0.775 3.244,0.67 5.239,2.064 2.424,1.695 5.171,3.617 7.487,2.099 2.314,-1.515 1.65,-4.795 1.06,-7.699 -0.482,-2.386 -0.984,-4.857 0.199,-5.63 1.18,-0.773 3.242,0.672 5.236,2.068 2.423,1.697 5.168,3.619 7.48,2.103 2.31,-1.515 1.642,-4.801 1.055,-7.695 -0.484,-2.387 -0.984,-4.852 0.193,-5.628 1.177,-0.771 3.24,0.674 5.233,2.07 2.422,1.697 5.167,3.62 7.479,2.105 2.306,-1.512 1.638,-4.796 1.05,-7.694 C -1.127,4.073 -1.628,1.607 -0.451,0.836 -0.158,0.644 0,0.324 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,799.5952,1190.7303)"
+         clip-path="url(#clipPath89)"
+         id="path245" />
+      <path
+         d="m 0,0 c 0,-0.096 -0.014,-0.193 -0.043,-0.289 -0.16,-0.529 -0.716,-0.828 -1.246,-0.668 -2.919,0.883 -5.889,-2.839 -8.761,-6.436 -3.286,-4.118 -6.686,-8.375 -10.902,-7.102 -4.216,1.273 -4.689,6.7 -5.147,11.951 -0.398,4.585 -0.812,9.328 -3.732,10.208 -2.913,0.881 -5.879,-2.841 -8.748,-6.438 -3.284,-4.12 -6.68,-8.379 -10.892,-7.107 -4.21,1.271 -4.679,6.699 -5.134,11.946 -0.396,4.585 -0.806,9.326 -3.717,10.206 -2.912,0.879 -5.878,-2.842 -8.747,-6.441 -3.284,-4.119 -6.678,-8.379 -10.887,-7.108 -4.207,1.271 -4.673,6.698 -5.126,11.945 -0.395,4.585 -0.803,9.323 -3.71,10.202 -0.528,0.16 -0.822,0.727 -0.668,1.246 0.16,0.529 0.716,0.828 1.246,0.668 4.206,-1.269 4.672,-6.696 5.125,-11.944 0.395,-4.583 0.803,-9.325 3.71,-10.203 2.912,-0.879 5.878,2.843 8.746,6.441 3.285,4.119 6.679,8.379 10.889,7.108 4.21,-1.271 4.678,-6.699 5.133,-11.946 0.397,-4.585 0.807,-9.326 3.718,-10.207 2.916,-0.881 5.882,2.841 8.75,6.44 3.284,4.118 6.68,8.377 10.89,7.106 4.216,-1.273 4.689,-6.7 5.147,-11.951 0.399,-4.584 0.813,-9.328 3.732,-10.208 2.919,-0.883 5.889,2.839 8.762,6.436 3.286,4.118 6.686,8.375 10.901,7.102 C -0.279,0.826 0,0.429 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1100.6897,711.9108)"
+         clip-path="url(#clipPath90)"
+         id="path246" />
+      <path
+         d="m 0,0 c 0,-0.238 -0.084,-0.474 -0.254,-0.666 -2.697,-3.021 -7.371,-1.316 -11.89,0.33 -3.893,1.42 -7.92,2.888 -9.714,0.879 -1.795,-2.007 0.117,-5.85 1.964,-9.559 2.146,-4.305 4.362,-8.755 1.668,-11.782 -2.701,-3.022 -7.375,-1.322 -11.896,0.324 -3.895,1.42 -7.924,2.886 -9.72,0.873 -1.803,-2.017 0.115,-5.852 1.962,-9.56 2.148,-4.308 4.37,-8.754 1.666,-11.785 -2.703,-3.028 -7.382,-1.327 -11.904,0.315 -3.897,1.416 -7.926,2.88 -9.728,0.863 -1.804,-2.013 0.109,-5.856 1.954,-9.568 2.147,-4.312 4.361,-8.762 1.658,-11.792 -0.367,-0.413 -0.999,-0.447 -1.411,-0.08 -0.412,0.367 -0.446,0.999 -0.081,1.411 1.807,2.023 -0.109,5.858 -1.954,9.569 -2.144,4.311 -4.364,8.765 -1.658,11.792 2.703,3.028 7.381,1.327 11.904,-0.315 3.897,-1.415 7.926,-2.88 9.728,-0.863 1.802,2.017 -0.113,5.85 -1.962,9.561 -2.146,4.307 -4.365,8.761 -1.666,11.784 2.701,3.023 7.375,1.322 11.896,-0.324 3.895,-1.42 7.923,-2.886 9.72,-0.873 1.8,2.021 -0.115,5.852 -1.965,9.558 -2.146,4.308 -4.364,8.758 -1.667,11.783 2.697,3.02 7.371,1.316 11.89,-0.331 3.893,-1.419 7.92,-2.887 9.714,-0.878 0.368,0.412 1,0.447 1.412,0.08 C -0.113,0.549 0,0.276 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,192.77373,255.46373)"
+         clip-path="url(#clipPath91)"
+         id="path247" />
+      <path
+         d="m 0,0 c 0,-0.062 -0.006,-0.125 -0.018,-0.188 -0.575,-3.065 -4.203,-3.776 -7.713,-4.463 -2.854,-0.559 -5.807,-1.139 -6.133,-2.873 -0.324,-1.726 2.214,-3.347 4.671,-4.905 3.021,-1.915 6.129,-3.909 5.565,-6.965 -0.576,-3.068 -4.204,-3.78 -7.713,-4.47 -2.855,-0.56 -5.807,-1.14 -6.135,-2.878 -0.33,-1.757 2.216,-3.349 4.671,-4.907 3.02,-1.92 6.131,-3.921 5.567,-6.967 -0.577,-3.074 -4.207,-3.788 -7.715,-4.48 -2.857,-0.562 -5.81,-1.144 -6.138,-2.886 -0.326,-1.724 2.217,-3.354 4.671,-4.917 3.019,-1.919 6.132,-3.905 5.563,-6.972 -0.101,-0.543 -0.625,-0.901 -1.165,-0.799 -0.545,0.101 -0.901,0.65 -0.799,1.166 0.343,1.755 -2.214,3.356 -4.671,4.918 -3.021,1.916 -6.155,3.898 -5.563,6.973 0.576,3.074 4.206,3.789 7.715,4.48 2.856,0.562 5.809,1.144 6.137,2.886 0.346,1.744 -2.216,3.349 -4.673,4.909 -3.021,1.918 -6.143,3.925 -5.565,6.965 0.576,3.07 4.207,3.783 7.715,4.472 2.855,0.56 5.807,1.14 6.134,2.876 0.347,1.759 -2.213,3.349 -4.671,4.907 -3.021,1.914 -6.139,3.888 -5.565,6.965 0.576,3.066 4.204,3.777 7.713,4.464 2.855,0.559 5.807,1.139 6.133,2.873 0.102,0.54 0.625,0.898 1.168,0.796 C -0.334,0.89 0,0.471 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,492.32187,1174.6012)"
+         clip-path="url(#clipPath92)"
+         id="path248" />
+      <path
+         d="m 0,0 c 0,-0.428 -0.276,-0.822 -0.705,-0.955 -0.746,-0.23 -0.887,-1.953 -1.009,-3.472 -0.174,-2.151 -0.372,-4.591 -2.412,-5.219 -2.041,-0.631 -3.577,1.273 -4.934,2.95 -0.959,1.187 -2.045,2.531 -2.793,2.301 -0.744,-0.231 -0.882,-1.951 -1.005,-3.47 -0.172,-2.152 -0.369,-4.591 -2.408,-5.22 -2.037,-0.631 -3.573,1.273 -4.929,2.955 -0.957,1.185 -2.042,2.528 -2.786,2.3 -0.742,-0.229 -0.881,-1.951 -1.004,-3.468 -0.171,-2.152 -0.369,-4.593 -2.407,-5.222 -2.037,-0.628 -3.572,1.276 -4.927,2.957 -0.957,1.185 -2.04,2.53 -2.781,2.302 -0.527,-0.164 -1.087,0.133 -1.249,0.66 -0.168,0.527 0.132,1.086 0.66,1.25 2.037,0.628 3.571,-1.275 4.926,-2.957 0.957,-1.185 2.041,-2.531 2.781,-2.302 0.744,0.231 0.882,1.953 1.006,3.472 0.172,2.152 0.369,4.591 2.405,5.217 2.039,0.631 3.576,-1.274 4.933,-2.954 0.954,-1.185 2.04,-2.529 2.782,-2.3 0.744,0.23 0.883,1.95 1.006,3.47 0.172,2.151 0.369,4.591 2.408,5.219 2.04,0.631 3.579,-1.273 4.936,-2.952 0.959,-1.186 2.044,-2.529 2.79,-2.299 0.746,0.231 0.887,1.953 1.01,3.472 0.174,2.152 0.371,4.591 2.412,5.22 0.527,0.164 1.087,-0.133 1.249,-0.66 C -0.014,0.197 0,0.098 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1134.25,1098.3063)"
+         clip-path="url(#clipPath93)"
+         id="path249" />
+      <path
+         d="m 0,0 c 0,-0.146 -0.031,-0.293 -0.098,-0.432 -0.769,-1.607 -2.794,-1.468 -4.419,-1.357 -0.915,0.061 -2.3,0.157 -2.483,-0.228 -0.206,-0.393 0.753,-1.404 1.374,-2.082 1.103,-1.201 2.48,-2.696 1.709,-4.297 -0.772,-1.61 -2.796,-1.473 -4.423,-1.362 -0.915,0.061 -2.298,0.155 -2.484,-0.232 -0.207,-0.381 0.752,-1.402 1.375,-2.08 1.105,-1.201 2.478,-2.687 1.709,-4.299 -0.774,-1.609 -2.798,-1.475 -4.425,-1.365 -0.916,0.062 -2.3,0.154 -2.486,-0.233 -0.195,-0.394 0.754,-1.411 1.373,-2.087 1.101,-1.197 2.476,-2.695 1.707,-4.302 -0.239,-0.498 -0.836,-0.709 -1.334,-0.47 -0.5,0.238 -0.709,0.839 -0.471,1.333 0.217,0.404 -0.752,1.412 -1.373,2.088 -1.103,1.197 -2.481,2.683 -1.706,4.301 0.771,1.61 2.796,1.475 4.423,1.365 0.917,-0.062 2.302,-0.154 2.487,0.235 0.202,0.384 -0.753,1.406 -1.376,2.081 -1.101,1.199 -2.47,2.701 -1.707,4.3 0.772,1.607 2.796,1.47 4.423,1.359 0.916,-0.061 2.298,-0.154 2.484,0.233 0.195,0.376 -0.754,1.402 -1.375,2.077 -1.105,1.203 -2.476,2.705 -1.709,4.302 0.772,1.607 2.797,1.468 4.423,1.357 0.916,-0.063 2.296,-0.156 2.48,0.227 0.238,0.497 0.836,0.708 1.334,0.47 C -0.209,0.73 0,0.373 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,450.7144,-1.6414667)"
+         clip-path="url(#clipPath94)"
+         id="path250" />
+      <path
+         d="m 0,0 c 0,-0.068 -0.002,-0.135 -0.004,-0.203 -0.156,-4.2 -5.026,-5.94 -9.736,-7.622 -4.083,-1.458 -8.303,-2.966 -8.408,-5.811 -0.002,-0.035 -0.002,-0.072 -0.002,-0.107 0,-2.777 4.042,-4.567 7.955,-6.301 4.573,-2.023 9.328,-4.027 9.144,-8.313 -0.156,-4.192 -5.026,-5.928 -9.736,-7.606 -4.083,-1.456 -8.305,-2.96 -8.41,-5.799 -0.117,-2.933 3.991,-4.653 7.953,-6.407 4.574,-2.023 9.213,-4.057 9.145,-8.308 -0.156,-4.189 -5.027,-5.923 -9.736,-7.598 -4.081,-1.453 -8.303,-2.956 -8.407,-5.79 -0.021,-0.552 -0.484,-0.982 -1.036,-0.963 -0.551,0.024 -0.949,0.413 -0.963,1.037 0.156,4.189 5.026,5.923 9.736,7.598 4.081,1.453 8.303,2.957 8.406,5.79 0.094,2.804 -3.989,4.653 -7.953,6.406 -4.571,2.026 -9.263,4.078 -9.144,8.309 0.158,4.193 5.028,5.929 9.737,7.608 4.083,1.455 8.303,2.96 8.409,5.797 0.14,2.822 -3.992,4.656 -7.955,6.411 -4.57,2.025 -9.28,4.11 -9.143,8.311 0.156,4.198 5.026,5.938 9.734,7.619 4.083,1.459 8.305,2.966 8.41,5.813 0.055,2.919 -3.991,4.663 -7.953,6.42 -4.571,2.027 -9.207,4.054 -9.142,8.323 0.021,0.553 0.484,0.982 1.037,0.962 0.55,-0.021 0.939,-0.517 0.962,-1.037 -0.199,-2.819 3.993,-4.662 7.954,-6.42 C -4.649,6.125 0,4.063 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,952.22947,96.778533)"
+         clip-path="url(#clipPath95)"
+         id="path251" />
+      <path
+         d="m 0,0 c 0,-0.191 -0.054,-0.383 -0.166,-0.552 -0.306,-0.461 -0.925,-0.586 -1.386,-0.282 -3.062,2.031 -7.68,-1.162 -12.148,-4.251 -5.014,-3.468 -10.198,-7.053 -14.389,-4.274 -4.19,2.781 -2.904,8.953 -1.666,14.92 1.111,5.319 2.25,10.818 -0.81,12.843 -3.056,2.027 -7.672,-1.168 -12.136,-4.259 -5.01,-3.47 -10.193,-7.057 -14.379,-4.282 -4.189,2.775 -2.898,8.943 -1.65,14.911 1.109,5.317 2.257,10.81 -0.799,12.834 -3.054,2.028 -7.67,-1.169 -12.134,-4.26 -5.011,-3.47 -10.191,-7.057 -14.376,-4.284 -4.174,2.773 -2.886,8.941 -1.64,14.905 1.111,5.313 2.263,10.804 -0.789,12.829 -0.462,0.308 -0.58,0.931 -0.281,1.386 0.307,0.461 0.926,0.586 1.386,0.281 4.181,-2.771 2.888,-8.937 1.641,-14.905 -1.113,-5.315 -2.265,-10.806 0.789,-12.829 3.053,-2.024 7.67,1.17 12.132,4.261 5.012,3.47 10.193,7.059 14.377,4.284 4.185,-2.778 2.894,-8.947 1.65,-14.91 -1.111,-5.316 -2.255,-10.812 0.799,-12.836 3.056,-2.026 7.672,1.168 12.135,4.259 5.011,3.471 10.194,7.057 14.38,4.283 4.191,-2.781 2.908,-8.951 1.664,-14.919 -1.107,-5.315 -2.253,-10.818 0.812,-12.845 3.062,-2.03 7.68,1.162 12.148,4.252 5.014,3.468 10.199,7.053 14.389,4.274 C -0.156,0.641 0,0.322 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,672.5876,1144.1319)"
+         clip-path="url(#clipPath96)"
+         id="path252" />
+      <path
+         d="m 0,0 c 0,-0.363 -0.199,-0.715 -0.545,-0.891 -3.592,-1.833 -7.316,1.432 -10.917,4.587 -3.101,2.718 -6.307,5.528 -8.691,4.312 -2.389,-1.219 -1.998,-5.469 -1.615,-9.568 0.439,-4.765 0.9,-9.699 -2.699,-11.537 -3.595,-1.835 -7.321,1.428 -10.923,4.583 -3.103,2.717 -6.311,5.526 -8.699,4.308 -2.392,-1.219 -2.002,-5.471 -1.617,-9.57 0.441,-4.767 0.894,-9.701 -2.701,-11.539 -3.601,-1.837 -7.33,1.424 -10.935,4.577 -3.104,2.717 -6.314,5.525 -8.709,4.302 -2.394,-1.222 -2.005,-5.465 -1.628,-9.576 0.441,-4.768 0.892,-9.701 -2.708,-11.54 -0.493,-0.252 -1.094,-0.057 -1.346,0.435 -0.246,0.493 -0.056,1.098 0.435,1.346 2.394,1.222 2.004,5.471 1.627,9.576 -0.433,4.776 -0.892,9.705 2.71,11.54 3.601,1.837 7.331,-1.423 10.936,-4.577 3.104,-2.716 6.314,-5.524 8.708,-4.302 2.392,1.221 2.002,5.472 1.619,9.574 -0.441,4.767 -0.894,9.699 2.699,11.535 3.597,1.835 7.322,-1.428 10.925,-4.585 3.103,-2.716 6.309,-5.524 8.697,-4.306 2.39,1.219 1.998,5.466 1.617,9.572 -0.436,4.77 -0.894,9.699 2.696,11.533 3.594,1.833 7.317,-1.432 10.918,-4.587 3.101,-2.718 6.307,-5.528 8.692,-4.312 0.491,0.252 1.095,0.057 1.345,-0.435 C -0.035,0.308 0,0.154 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,614.98387,333.4612)"
+         clip-path="url(#clipPath97)"
+         id="path253" />
+      <path
+         d="m 0,0 c 0,-0.354 -0.19,-0.697 -0.521,-0.879 -1.489,-0.808 -2.945,0.403 -4.119,1.377 -0.554,0.461 -1.587,1.32 -1.884,1.158 -0.301,-0.162 -0.14,-1.498 -0.053,-2.213 0.182,-1.511 0.402,-3.395 -1.082,-4.206 -1.489,-0.81 -2.948,0.403 -4.121,1.375 -0.555,0.461 -1.588,1.318 -1.885,1.156 -0.297,-0.16 -0.141,-1.495 -0.055,-2.212 0.182,-1.519 0.403,-3.4 -1.081,-4.206 -1.49,-0.811 -2.951,0.4 -4.124,1.372 -0.557,0.461 -1.592,1.319 -1.891,1.155 -0.302,-0.161 -0.14,-1.498 -0.056,-2.215 0.18,-1.515 0.402,-3.398 -1.086,-4.208 -0.484,-0.263 -1.091,-0.084 -1.357,0.4 -0.264,0.489 -0.084,1.092 0.4,1.358 0.303,0.16 0.145,1.501 0.057,2.216 -0.182,1.501 -0.404,3.394 1.085,4.206 1.49,0.81 2.949,-0.401 4.123,-1.373 0.556,-0.461 1.591,-1.318 1.892,-1.154 0.3,0.162 0.14,1.496 0.052,2.21 -0.183,1.518 -0.402,3.4 1.084,4.209 1.488,0.81 2.947,-0.403 4.118,-1.375 0.557,-0.461 1.59,-1.318 1.889,-1.156 0.301,0.16 0.138,1.498 0.053,2.212 -0.178,1.51 -0.403,3.394 1.081,4.206 1.488,0.809 2.947,-0.404 4.12,-1.376 0.555,-0.461 1.588,-1.32 1.883,-1.158 0.486,0.264 1.091,0.084 1.357,-0.401 C -0.039,0.326 0,0.162 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,972.1572,1227.2376)"
+         clip-path="url(#clipPath98)"
+         id="path254" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.58 -0.371,-0.777 -3.511,-2.847 -8.418,-0.1 -13.163,2.556 -4.165,2.329 -8.471,4.741 -10.929,2.745 -2.464,-1.997 -1,-6.709 0.422,-11.263 1.615,-5.198 3.284,-10.568 -0.231,-13.417 -3.514,-2.85 -8.423,-0.105 -13.171,2.55 -4.165,2.33 -8.472,4.738 -10.936,2.74 -2.462,-1.997 -0.998,-6.709 0.42,-11.267 1.614,-5.196 3.286,-10.568 -0.233,-13.417 -3.519,-2.854 -8.431,-0.111 -13.18,2.541 -4.169,2.327 -8.481,4.733 -10.951,2.732 -2.466,-2.002 -1.004,-6.72 0.412,-11.277 1.615,-5.19 3.286,-10.564 -0.242,-13.423 -0.428,-0.347 -1.059,-0.281 -1.406,0.149 -0.35,0.421 -0.285,1.056 0.148,1.406 2.467,1.997 1.004,6.713 -0.41,11.276 -1.611,5.195 -3.276,10.568 0.238,13.423 3.523,2.855 8.434,0.111 13.185,-2.541 4.169,-2.327 8.478,-4.733 10.949,-2.731 2.462,1.997 0.997,6.711 -0.42,11.267 -1.617,5.196 -3.288,10.568 0.232,13.417 3.515,2.85 8.424,0.105 13.171,-2.551 4.165,-2.329 8.472,-4.737 10.937,-2.739 2.456,1.992 0.996,6.707 -0.422,11.267 -1.617,5.194 -3.288,10.56 0.229,13.413 3.51,2.847 8.418,0.101 13.165,-2.557 4.163,-2.329 8.468,-4.739 10.929,-2.745 0.427,0.348 1.058,0.281 1.406,-0.148 C -0.072,0.445 0,0.222 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,963.1224,388.9588)"
+         clip-path="url(#clipPath99)"
+         id="path255" />
+      <path
+         d="m 0,0 c 0,-0.869 -0.24,-1.668 -1.002,-2.21 -1.484,-1.059 -3.237,0.07 -4.647,0.976 -0.807,0.517 -2.025,1.3 -2.406,1.029 -0.377,-0.273 -0.035,-1.677 0.194,-2.607 0.394,-1.634 0.89,-3.657 -0.59,-4.709 -1.482,-1.057 -3.236,0.072 -4.644,0.978 -0.806,0.519 -2.023,1.302 -2.399,1.031 -0.383,-0.27 -0.038,-1.676 0.191,-2.607 0.416,-1.711 0.892,-3.65 -0.59,-4.708 -1.482,-1.055 -3.161,0.027 -4.641,0.98 -0.807,0.52 -2.023,1.303 -2.398,1.033 -0.451,-0.32 -1.074,-0.217 -1.396,0.232 -0.319,0.45 -0.215,1.073 0.232,1.397 1.482,1.056 3.236,-0.072 4.643,-0.981 0.805,-0.517 2.023,-1.302 2.4,-1.033 0.379,0.266 0.033,1.676 -0.193,2.605 -0.398,1.627 -0.893,3.654 0.59,4.71 1.48,1.057 3.233,-0.07 4.643,-0.978 0.805,-0.518 2.023,-1.301 2.402,-1.031 0.377,0.263 0.033,1.675 -0.194,2.605 -0.398,1.63 -0.892,3.651 0.59,4.712 1.484,1.056 3.238,-0.071 4.646,-0.977 0.806,-0.517 2.025,-1.3 2.407,-1.029 0.381,0.274 0.041,1.679 -0.189,2.611 -0.398,1.621 -0.892,3.649 0.593,4.71 0.449,0.32 1.075,0.215 1.395,-0.234 C -0.045,6.057 -0.148,5.43 -0.597,5.11 -0.978,4.833 -0.637,3.433 -0.408,2.501 -0.215,1.71 0,0.824 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1116.3427,1014.3543)"
+         clip-path="url(#clipPath100)"
+         id="path256" />
+      <path
+         d="m 0,0 c 0,-0.176 -0.045,-0.353 -0.143,-0.513 -2.65,-4.417 -9.05,-3.375 -15.24,-2.367 -5.532,0.9 -11.254,1.829 -13.206,-1.422 -1.959,-3.259 1.556,-7.871 4.954,-12.331 3.798,-4.989 7.73,-10.154 5.076,-14.571 -2.653,-4.421 -9.054,-3.382 -15.246,-2.376 -5.534,0.896 -11.257,1.826 -13.212,-1.432 -1.952,-3.272 1.555,-7.873 4.952,-12.335 3.798,-4.989 7.733,-10.151 5.075,-14.572 -2.655,-4.427 -9.06,-3.392 -15.254,-2.392 -5.536,0.894 -11.261,1.819 -13.22,-1.445 -1.948,-3.263 1.549,-7.881 4.945,-12.347 3.798,-4.995 7.728,-10.168 5.067,-14.584 -0.283,-0.475 -0.899,-0.63 -1.371,-0.344 -0.473,0.287 -0.629,0.906 -0.344,1.371 1.961,3.27 -1.55,7.882 -4.944,12.346 -3.798,4.991 -7.733,10.16 -5.067,14.585 2.656,4.426 9.059,3.392 15.252,2.392 5.538,-0.894 11.261,-1.82 13.222,1.445 1.947,3.263 -1.556,7.873 -4.952,12.335 -3.8,4.989 -7.733,10.154 -5.075,14.573 2.654,4.42 9.054,3.382 15.246,2.376 5.534,-0.896 11.258,-1.826 13.212,1.431 1.949,3.252 -1.56,7.872 -4.954,12.332 -3.8,4.989 -7.734,10.146 -5.077,14.571 2.65,4.416 9.051,3.374 15.241,2.366 5.532,-0.9 11.253,-1.83 13.206,1.421 0.285,0.475 0.898,0.629 1.371,0.344 C -0.174,0.67 0,0.338 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,885.7344,760.41013)"
+         clip-path="url(#clipPath101)"
+         id="path257" />
+      <path
+         d="m 0,0 c 0,-0.039 -0.002,-0.08 -0.008,-0.119 -0.183,-1.556 -1.831,-1.998 -3.157,-2.351 -0.506,-0.135 -1.56,-0.418 -1.689,-0.658 0.07,-0.258 1.029,-0.779 1.49,-1.029 1.204,-0.652 2.724,-1.457 2.519,-3.027 -0.184,-1.554 -1.83,-1.995 -3.154,-2.351 -0.508,-0.134 -1.562,-0.418 -1.691,-0.658 0.07,-0.259 1.029,-0.781 1.49,-1.031 1.205,-0.652 2.73,-1.457 2.519,-3.024 -0.184,-1.559 -1.832,-2.002 -3.158,-2.357 -0.505,-0.137 -1.562,-0.422 -1.689,-0.662 0.067,-0.262 1.028,-0.785 1.49,-1.035 1.205,-0.656 2.717,-1.471 2.519,-3.029 -0.064,-0.549 -0.56,-0.941 -1.109,-0.875 -0.547,0.063 -0.969,0.575 -0.875,1.109 -0.066,0.264 -1.029,0.785 -1.49,1.037 -1.206,0.656 -2.729,1.441 -2.519,3.031 0.184,1.554 1.832,1.998 3.156,2.353 0.508,0.137 1.564,0.422 1.691,0.662 -0.07,0.262 -1.029,0.783 -1.49,1.033 -1.205,0.654 -2.72,1.47 -2.519,3.026 0.184,1.555 1.832,1.998 3.156,2.354 0.507,0.134 1.56,0.417 1.689,0.657 -0.07,0.258 -1.029,0.78 -1.49,1.029 -1.203,0.653 -2.732,1.448 -2.519,3.025 0.184,1.556 1.832,1.998 3.157,2.351 0.506,0.135 1.561,0.418 1.689,0.658 0.067,0.549 0.563,0.938 1.111,0.873 C -0.373,0.931 0,0.5 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,559.0356,1180.3449)"
+         clip-path="url(#clipPath102)"
+         id="path258" />
+      <path
+         d="m 0,0 c 0,-0.547 -0.44,-0.992 -0.986,-1 -0.553,-0.007 -1.006,0.434 -1.014,0.986 -0.041,2.935 -4.341,4.583 -8.498,6.179 -4.78,1.833 -9.722,3.727 -9.783,8.019 v 0.078 c 0,4.238 4.857,6.259 9.553,8.213 4.112,1.711 8.397,3.558 8.322,6.417 -0.041,2.929 -4.338,4.575 -8.496,6.166 -4.78,1.83 -9.722,3.722 -9.783,8.008 v 0.078 c 0,4.23 4.857,6.249 9.555,8.2 4.11,1.706 8.283,3.411 8.32,6.402 -0.041,2.928 -4.341,4.574 -8.498,6.165 -4.78,1.83 -9.722,3.72 -9.783,8.004 0.037,4.235 4.827,6.309 9.554,8.27 4.092,1.697 8.321,3.452 8.321,6.35 -0.002,0.018 -0.006,0.033 0,0.056 0,0.547 0.437,0.992 0.986,1 0.552,0.008 1.005,-0.433 1.013,-0.986 v -0.078 c 0,-4.226 -4.856,-6.241 -9.552,-8.189 -4.093,-1.697 -8.322,-3.453 -8.322,-6.353 v -0.043 c 0.041,-2.927 4.34,-4.573 8.498,-6.164 4.78,-1.83 9.722,-3.72 9.782,-8.004 v -0.078 c 0,-4.23 -4.856,-6.249 -9.554,-8.199 -4.11,-1.707 -8.318,-3.494 -8.32,-6.403 0.041,-2.931 4.341,-4.577 8.498,-6.169 4.778,-1.829 9.72,-3.722 9.781,-8.006 0.033,-4.382 -4.829,-6.325 -9.553,-8.291 -4.093,-1.703 -8.322,-3.462 -8.322,-6.373 v -0.043 c 0.041,-2.937 4.341,-4.585 8.5,-6.181 C -5.003,6.198 -0.061,4.304 0,0.014 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1076.5993,1301.3533)"
+         clip-path="url(#clipPath103)"
+         id="path259" />
+      <path
+         d="m 0,0 c 0,-0.137 -0.014,-0.281 -0.043,-0.427 -0.322,-1.647 -2.16,-1.996 -3.636,-2.276 -0.644,-0.123 -1.988,-0.376 -2.05,-0.695 0.043,-0.357 1.089,-1.054 1.636,-1.411 1.265,-0.813 2.837,-1.828 2.517,-3.474 -0.324,-1.646 -2.164,-1.994 -3.64,-2.273 -0.644,-0.121 -1.984,-0.375 -2.044,-0.689 -0.032,-0.28 1.085,-1.059 1.634,-1.412 1.265,-0.815 2.826,-1.861 2.513,-3.474 -0.32,-1.644 -2.159,-1.992 -3.635,-2.269 -0.645,-0.121 -1.984,-0.373 -2.047,-0.688 -0.105,-0.542 -0.631,-0.896 -1.171,-0.788 -0.546,0.103 -0.901,0.634 -0.79,1.171 0.321,1.645 2.16,1.992 3.636,2.269 0.645,0.121 1.984,0.373 2.047,0.688 0.062,0.34 -1.086,1.058 -1.637,1.411 -1.263,0.815 -2.843,1.853 -2.513,3.474 0.321,1.646 2.158,1.992 3.636,2.271 0.645,0.121 1.986,0.375 2.049,0.691 0.044,0.377 -1.084,1.055 -1.637,1.412 -1.265,0.814 -2.821,1.828 -2.517,3.474 0.325,1.648 2.162,1.998 3.64,2.277 0.644,0.123 1.986,0.377 2.048,0.693 -0.004,0.359 -1.083,1.058 -1.636,1.416 -1.263,0.816 -2.818,1.828 -2.515,3.478 0.106,0.54 0.631,0.896 1.174,0.79 0.542,-0.107 0.882,-0.65 0.79,-1.173 C -4.317,4.085 -3.107,3.406 -2.556,3.05 -1.406,2.308 0,1.4 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1153.9175,586.5152)"
+         clip-path="url(#clipPath104)"
+         id="path260" />
+      <path
+         d="m 0,0 c 0,-0.017 0,-0.035 -0.002,-0.054 -0.104,-1.904 -2.117,-2.582 -3.894,-3.178 -1.056,-0.355 -2.503,-0.841 -2.534,-1.392 -0.024,-0.482 1.355,-1.195 2.367,-1.663 1.7,-0.789 3.674,-1.764 3.522,-3.588 -0.105,-1.905 -2.119,-2.583 -3.894,-3.18 -1.056,-0.356 -2.503,-0.844 -2.534,-1.396 -0.039,-0.637 1.353,-1.194 2.366,-1.664 1.697,-0.789 3.638,-1.632 3.521,-3.589 -0.103,-1.906 -2.116,-2.586 -3.892,-3.185 -1.056,-0.356 -2.505,-0.846 -2.536,-1.4 -0.055,-0.572 1.355,-1.199 2.367,-1.67 1.699,-0.79 3.637,-1.595 3.52,-3.591 -0.029,-0.55 -0.502,-0.974 -1.052,-0.943 -0.551,0.03 -0.971,0.449 -0.943,1.053 -0.051,0.497 -1.358,1.199 -2.367,1.669 -1.699,0.789 -3.704,1.608 -3.521,3.591 0.104,1.908 2.117,2.587 3.894,3.187 1.056,0.355 2.503,0.844 2.535,1.398 -0.049,0.625 -1.356,1.195 -2.369,1.666 -1.699,0.787 -3.691,1.636 -3.519,3.587 0.104,1.906 2.117,2.583 3.892,3.181 1.058,0.357 2.505,0.843 2.536,1.396 v 0.019 c 0,0.547 -1.367,1.18 -2.366,1.645 -1.699,0.786 -3.693,1.605 -3.523,3.586 0.103,1.904 2.117,2.582 3.894,3.178 1.056,0.355 2.503,0.841 2.534,1.392 0.03,0.55 0.502,0.974 1.053,0.943 C -0.412,0.969 0,0.527 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,913.168,836.29133)"
+         clip-path="url(#clipPath105)"
+         id="path261" />
+      <path
+         d="m 0,0 c 0,-0.484 -0.06,-0.978 -0.186,-1.484 -1.247,-5.042 -7.715,-5.938 -13.969,-6.805 -5.594,-0.775 -11.38,-1.576 -12.302,-5.301 -0.904,-3.703 3.822,-7.122 8.412,-10.416 5.13,-3.679 10.432,-7.463 9.188,-12.519 -1.246,-5.034 -7.713,-5.926 -13.966,-6.787 -5.592,-0.771 -11.376,-1.568 -12.296,-5.286 -0.914,-3.722 3.823,-7.122 8.412,-10.412 5.13,-3.68 10.434,-7.486 9.19,-12.516 -1.244,-5.028 -7.712,-5.917 -13.964,-6.776 -5.594,-0.769 -11.376,-1.564 -12.296,-5.276 -0.133,-0.537 -0.676,-0.863 -1.211,-0.731 -0.535,0.133 -0.867,0.676 -0.73,1.211 1.244,5.028 7.711,5.917 13.964,6.776 5.594,0.769 11.376,1.564 12.296,5.276 0.929,3.739 -3.825,7.122 -8.414,10.412 -5.13,3.68 -10.428,7.51 -9.188,12.516 1.246,5.032 7.712,5.925 13.964,6.786 5.594,0.771 11.378,1.57 12.298,5.288 0.912,3.729 -3.827,7.123 -8.41,10.414 -5.132,3.68 -10.44,7.48 -9.19,12.52 1.248,5.04 7.714,5.936 13.968,6.803 5.596,0.775 11.382,1.576 12.304,5.304 0.915,3.708 -3.822,7.132 -8.409,10.429 -5.131,3.683 -10.437,7.492 -9.183,12.532 0.133,0.535 0.674,0.863 1.211,0.73 0.533,-0.132 0.859,-0.665 0.73,-1.211 -0.925,-3.713 3.821,-7.134 8.408,-10.427 C -4.755,7.737 -0.002,4.321 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,35.028667,1293.7172)"
+         clip-path="url(#clipPath106)"
+         id="path262" />
+      <path
+         d="m 0,0 c 0,-0.02 0,-0.041 -0.002,-0.062 -0.035,-0.553 -0.509,-0.971 -1.06,-0.936 -4.339,0.276 -7.143,-5.629 -9.853,-11.341 -2.998,-6.311 -6.099,-12.837 -11.787,-12.477 -5.69,0.359 -7.943,7.222 -10.124,13.862 -1.971,6.006 -4.009,12.215 -8.348,12.491 -4.329,0.273 -7.129,-5.632 -9.837,-11.343 -2.994,-6.311 -6.089,-12.839 -11.771,-12.48 -5.683,0.359 -7.93,7.223 -10.106,13.862 -1.966,6.007 -4,12.216 -8.328,12.489 -4.329,0.274 -7.129,-5.631 -9.835,-11.343 -2.992,-6.31 -6.087,-12.838 -11.765,-12.479 -5.677,0.359 -7.922,7.223 -10.094,13.862 -1.964,6.005 -3.995,12.214 -8.316,12.487 -0.551,0.034 -1.011,0.451 -0.935,1.061 0.035,0.55 0.509,0.97 1.06,0.935 5.676,-0.358 7.922,-7.223 10.093,-13.862 1.965,-6.005 3.995,-12.214 8.317,-12.488 4.327,-0.273 7.127,5.632 9.834,11.341 2.991,6.314 6.086,12.842 11.766,12.482 5.683,-0.359 7.93,-7.223 10.105,-13.862 1.967,-6.006 4.001,-12.216 8.329,-12.489 4.331,-0.274 7.131,5.631 9.837,11.341 2.993,6.313 6.091,12.839 11.771,12.481 5.69,-0.359 7.943,-7.224 10.123,-13.864 1.972,-6.004 4.011,-12.216 8.349,-12.489 4.339,-0.275 7.143,5.63 9.856,11.341 2.995,6.311 6.096,12.837 11.784,12.478 C -0.406,0.965 0,0.523 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,538.4468,990.00573)"
+         clip-path="url(#clipPath107)"
+         id="path263" />
+      <path
+         d="m 0,0 c 0,-0.119 -0.022,-0.24 -0.066,-0.358 -0.198,-0.515 -0.775,-0.773 -1.291,-0.575 -2.775,1.064 -2.82,4.557 -2.864,7.935 -0.036,2.713 -0.071,5.518 -1.58,6.097 -1.512,0.579 -3.416,-1.483 -5.255,-3.474 -2.295,-2.484 -4.665,-5.05 -7.442,-3.986 -2.776,1.064 -2.825,4.56 -2.87,7.94 -0.037,2.712 -0.074,5.518 -1.586,6.098 -1.511,0.58 -3.415,-1.482 -5.256,-3.474 -2.295,-2.484 -4.667,-5.05 -7.444,-3.985 -2.78,1.066 -2.829,4.561 -2.878,7.939 -0.037,2.715 -0.076,5.522 -1.594,6.105 -1.517,0.581 -3.422,-1.479 -5.266,-3.472 -2.294,-2.48 -4.668,-5.046 -7.447,-3.98 -0.516,0.197 -0.77,0.781 -0.576,1.291 0.197,0.515 0.775,0.773 1.29,0.576 1.517,-0.582 3.423,1.478 5.267,3.471 2.294,2.481 4.669,5.046 7.447,3.98 2.783,-1.066 2.831,-4.561 2.879,-7.941 0.038,-2.715 0.078,-5.521 1.593,-6.103 1.513,-0.58 3.417,1.482 5.26,3.476 2.293,2.482 4.663,5.048 7.44,3.984 2.777,-1.064 2.825,-4.56 2.871,-7.94 0.036,-2.712 0.074,-5.518 1.585,-6.098 1.512,-0.58 3.417,1.482 5.259,3.476 2.292,2.482 4.663,5.047 7.437,3.983 2.777,-1.064 2.822,-4.557 2.865,-7.937 C -2.187,4.315 -2.15,1.511 -0.642,0.933 -0.244,0.781 0,0.402 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,436.24893,531.21)"
+         clip-path="url(#clipPath108)"
+         id="path264" />
+      <path
+         d="m 0,0 c 0,-0.129 -0.025,-0.26 -0.078,-0.385 -0.213,-0.509 -0.797,-0.75 -1.306,-0.537 l -53.56,22.374 13.838,-33.695 c 0.145,-0.369 0.069,-0.803 -0.22,-1.088 -0.287,-0.285 -0.717,-0.369 -1.09,-0.213 l -50.68,21.173 c -0.511,0.213 -0.753,0.801 -0.536,1.307 0.212,0.509 0.796,0.749 1.306,0.537 l 48.453,-20.242 -13.838,33.695 c -0.15,0.361 -0.066,0.803 0.221,1.088 0.286,0.285 0.716,0.369 1.089,0.213 L -0.615,0.922 C -0.23,0.761 0,0.391 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1034.5305,294.51707)"
+         clip-path="url(#clipPath109)"
+         id="path265" />
+      <path
+         d="m 0,0 c 0,-0.525 -0.41,-0.967 -0.941,-0.998 l -47.025,-2.79 24.379,-21.648 c 0.299,-0.269 0.414,-0.697 0.282,-1.076 -0.133,-0.38 -0.483,-0.646 -0.887,-0.669 l -54.415,-3.228 c -0.551,-0.033 -1.023,0.386 -1.056,0.939 -0.077,0.529 0.388,1.023 0.939,1.057 l 52.005,3.085 -24.379,21.647 c -0.302,0.269 -0.418,0.687 -0.281,1.076 0.133,0.381 0.482,0.646 0.887,0.67 L -1.059,0.998 C -0.508,1.031 -0.035,0.611 -0.002,0.058 0,0.039 0,0.019 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,936.5872,651.09387)"
+         clip-path="url(#clipPath110)"
+         id="path266" />
+      <path
+         d="m 0,0 c 0,-0.305 -0.14,-0.608 -0.404,-0.803 l -35.562,-26.365 30.265,-4.495 c 0.4,-0.058 0.724,-0.353 0.823,-0.746 0.096,-0.394 -0.052,-0.804 -0.374,-1.044 l -41.28,-30.605 c -0.443,-0.33 -1.07,-0.236 -1.398,0.207 -0.327,0.446 -0.235,1.072 0.207,1.398 l 39.34,29.167 -30.264,4.496 c -0.4,0.058 -0.725,0.353 -0.824,0.746 -0.098,0.392 0.048,0.804 0.375,1.044 L -1.595,0.803 c 0.443,0.329 1.07,0.236 1.398,-0.208 C -0.064,0.416 0,0.207 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,207.34053,1092.4637)"
+         clip-path="url(#clipPath111)"
+         id="path267" />
+      <path
+         d="m 0,0 c 0,-0.131 -0.025,-0.262 -0.078,-0.389 -0.217,-0.509 -0.803,-0.748 -1.31,-0.533 l -30.509,12.904 7.672,-18.92 c 0.153,-0.373 0.065,-0.802 -0.225,-1.087 -0.286,-0.284 -0.718,-0.366 -1.089,-0.21 L -55.276,4.343 c -0.51,0.216 -0.742,0.806 -0.534,1.31 0.217,0.51 0.803,0.748 1.311,0.533 l 27.515,-11.638 -7.672,18.92 c -0.152,0.373 -0.064,0.802 0.225,1.087 0.286,0.284 0.718,0.366 1.089,0.209 L -0.611,0.922 C -0.228,0.76 0,0.389 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,891.38907,554.99387)"
+         clip-path="url(#clipPath112)"
+         id="path268" />
+      <path
+         d="m 0,0 c 0,-0.353 -0.189,-0.697 -0.523,-0.879 l -24.332,-13.202 18.089,-5.364 c 0.387,-0.115 0.668,-0.452 0.709,-0.855 0.045,-0.4 -0.162,-0.789 -0.517,-0.982 l -29.119,-15.797 c -0.484,-0.264 -1.091,-0.084 -1.355,0.402 -0.262,0.477 -0.086,1.088 0.402,1.355 l 26.996,14.647 -18.09,5.364 c -0.386,0.115 -0.667,0.453 -0.708,0.856 -0.049,0.394 0.162,0.789 0.517,0.982 L -1.476,0.879 C -0.992,1.143 -0.385,0.963 -0.121,0.477 -0.039,0.326 0,0.162 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,27.5824,927.24693)"
+         clip-path="url(#clipPath113)"
+         id="path269" />
+      <path
+         d="m 0,0 c 0,-0.211 -0.066,-0.422 -0.203,-0.603 -0.332,-0.44 -0.959,-0.528 -1.4,-0.194 l -21.718,16.424 2.548,-18.37 c 0.055,-0.389 -0.136,-0.795 -0.484,-1 -0.349,-0.203 -0.787,-0.178 -1.109,0.066 l -26.021,19.683 c -0.442,0.332 -0.528,0.955 -0.194,1.4 0.332,0.44 0.959,0.527 1.4,0.194 l 24.096,-18.227 -2.548,18.371 c -0.049,0.391 0.137,0.797 0.484,1 0.35,0.203 0.787,0.177 1.11,-0.067 L -0.396,0.797 C -0.137,0.601 0,0.303 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,265.80653,365.6336)"
+         clip-path="url(#clipPath114)"
+         id="path270" />
+      <path
+         d="m 0,0 c 0,-0.254 -0.098,-0.51 -0.291,-0.705 l -7.795,-7.846 6.241,0.02 c 0.404,0.002 0.771,-0.243 0.925,-0.615 0.157,-0.371 0.071,-0.801 -0.213,-1.09 l -8.626,-8.684 c -0.389,-0.39 -1.022,-0.394 -1.414,-0.004 -0.393,0.387 -0.393,1.02 -0.004,1.414 l 6.926,6.971 -6.241,-0.019 c -0.404,-0.002 -0.771,0.24 -0.925,0.615 -0.16,0.367 -0.074,0.8 0.212,1.089 l 9.496,9.559 c 0.389,0.39 1.022,0.394 1.414,0.004 C -0.098,0.513 0,0.258 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,894.39373,1133.1861)"
+         clip-path="url(#clipPath115)"
+         id="path271" />
+      <path
+         d="m 0,0 c 0,-0.324 -0.158,-0.645 -0.451,-0.836 l -8.317,-5.452 5.409,-1.127 c 0.396,-0.082 0.703,-0.394 0.779,-0.792 0.067,-0.387 -0.095,-0.801 -0.433,-1.022 l -9.389,-6.154 c -0.462,-0.303 -1.081,-0.174 -1.384,0.287 -0.305,0.454 -0.178,1.078 0.287,1.384 l 7.371,4.833 -5.409,1.125 c -0.396,0.082 -0.703,0.394 -0.779,0.79 -0.074,0.395 0.096,0.801 0.434,1.024 L -1.548,0.835 C -1.086,1.138 -0.467,1.009 -0.164,0.549 -0.053,0.379 0,0.189 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1193.7989,1017.5849)"
+         clip-path="url(#clipPath116)"
+         id="path272" />
+      <path
+         d="m 0,0 c 0,-0.255 -0.098,-0.513 -0.295,-0.709 l -33.371,-33.24 32.6,-0.064 c 0.404,0 0.769,-0.247 0.922,-0.619 0.154,-0.371 0.07,-0.803 -0.219,-1.09 l -38.614,-38.466 c -0.391,-0.388 -1.024,-0.388 -1.414,0.004 -0.387,0.391 -0.391,1.023 0.004,1.414 l 36.903,36.761 -32.6,0.064 c -0.404,0 -0.769,0.246 -0.921,0.619 -0.148,0.375 -0.068,0.803 0.219,1.09 L -1.705,0.709 C -1.314,1.098 -0.681,1.098 -0.291,0.705 -0.098,0.51 0,0.256 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1018.8104,1062.4605)"
+         clip-path="url(#clipPath117)"
+         id="path273" />
+      <path
+         d="m 0,0 c 0,-0.297 -0.131,-0.59 -0.383,-0.787 -0.435,-0.34 -1.064,-0.264 -1.404,0.17 l -27.282,34.861 -3.705,-30.37 c -0.049,-0.402 -0.334,-0.734 -0.724,-0.841 -0.389,-0.11 -0.807,0.027 -1.054,0.345 l -31.669,40.464 c -0.338,0.433 -0.266,1.062 0.17,1.403 0.435,0.34 1.064,0.264 1.404,-0.17 l 30.181,-38.563 3.703,30.37 c 0.049,0.402 0.334,0.734 0.725,0.842 0.388,0.109 0.806,-0.028 1.054,-0.346 L -0.213,0.617 C -0.07,0.434 0,0.217 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1262.9287,885.04013)"
+         clip-path="url(#clipPath118)"
+         id="path274" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.578 -0.369,-0.777 -0.43,-0.348 -1.061,-0.281 -1.408,0.146 l -29.247,36.06 -3.003,-28.805 c -0.042,-0.403 -0.323,-0.741 -0.709,-0.856 -0.389,-0.115 -0.807,0.016 -1.063,0.328 l -27.952,34.461 c -0.348,0.426 -0.283,1.055 0.146,1.408 0.43,0.348 1.059,0.281 1.408,-0.146 l 26.432,-32.587 3.003,28.806 c 0.041,0.402 0.322,0.74 0.709,0.855 0.388,0.116 0.806,-0.015 1.062,-0.327 L -0.223,0.631 C -0.072,0.445 0,0.223 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,534.39333,224.73907)"
+         clip-path="url(#clipPath119)"
+         id="path275" />
+      <path
+         d="m 0,0 c 0,-0.539 -0.43,-0.984 -0.973,-1 l -27.253,-0.769 12.103,-11.437 c 0.295,-0.275 0.394,-0.703 0.246,-1.082 -0.143,-0.379 -0.502,-0.632 -0.906,-0.644 l -26.951,-0.762 c -0.551,-0.015 -1.012,0.42 -1.027,0.973 -0.008,0.49 0.42,1.011 0.972,1.027 l 24.537,0.693 -12.102,11.437 c -0.291,0.277 -0.389,0.707 -0.246,1.082 0.142,0.378 0.502,0.632 0.906,0.644 L -1.027,1 C -0.477,1.015 -0.016,0.58 0,0.028 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,273.64853,175.61747)"
+         clip-path="url(#clipPath120)"
+         id="path276" />
+      <path
+         d="m 0,0 c 0,-0.135 -0.027,-0.27 -0.082,-0.398 l -5.346,-12.326 c -0.221,-0.505 -0.809,-0.738 -1.316,-0.519 -0.508,0.218 -0.739,0.801 -0.52,1.316 l 4.388,10.111 -6.593,-2.601 c -0.376,-0.148 -0.804,-0.057 -1.085,0.234 -0.279,0.29 -0.359,0.721 -0.199,1.094 l 5.885,13.565 c 0.221,0.506 0.809,0.738 1.316,0.519 0.506,-0.22 0.728,-0.804 0.52,-1.316 l -4.925,-11.351 6.59,2.601 C -0.99,1.078 -0.562,0.986 -0.281,0.695 -0.098,0.505 0,0.254 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1256.11,1247.4724)"
+         clip-path="url(#clipPath121)"
+         id="path277" />
+      <path
+         d="m 0,0 c 0,-0.525 -0.41,-0.967 -0.941,-0.998 -0.551,-0.033 -1.023,0.387 -1.057,0.939 L -4.847,47.932 -24.78,25.482 c -0.269,-0.302 -0.693,-0.414 -1.076,-0.281 -0.38,0.133 -0.646,0.482 -0.669,0.887 l -2.716,45.788 c -0.043,0.568 0.388,1.023 0.939,1.056 0.55,0.034 1.023,-0.386 1.056,-0.939 l 2.574,-43.379 19.933,22.45 c 0.269,0.303 0.693,0.414 1.075,0.281 0.382,-0.132 0.647,-0.482 0.67,-0.886 L -0.002,0.058 C 0,0.039 0,0.019 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,85.8976,235.81173)"
+         clip-path="url(#clipPath122)"
+         id="path278" />
+      <path
+         d="m 0,0 c 0,-0.156 -0.037,-0.314 -0.111,-0.459 l -5.378,-10.415 c -0.254,-0.491 -0.857,-0.684 -1.347,-0.43 -0.49,0.254 -0.682,0.859 -0.43,1.347 l 4.271,8.272 -4.874,-1.556 c -0.387,-0.123 -0.807,-0.002 -1.069,0.308 -0.261,0.307 -0.31,0.746 -0.124,1.103 l 4.885,9.463 c 0.254,0.49 0.857,0.683 1.348,0.43 C -2.337,7.809 -2.15,7.202 -2.4,6.715 l -3.778,-7.318 4.873,1.556 C -0.918,1.076 -0.498,0.955 -0.236,0.645 -0.08,0.461 0,0.23 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,870.8184,227.116)"
+         clip-path="url(#clipPath123)"
+         id="path279" />
+      <path
+         d="m 0,0 c 0,-0.078 -0.01,-0.156 -0.029,-0.236 -0.129,-0.537 -0.67,-0.865 -1.207,-0.735 l -55.175,13.435 18.51,-30.429 c 0.211,-0.343 0.193,-0.785 -0.047,-1.109 -0.238,-0.326 -0.651,-0.476 -1.043,-0.381 l -52.256,12.726 c -0.537,0.131 -0.871,0.664 -0.734,1.207 0.129,0.537 0.67,0.865 1.207,0.734 l 49.91,-12.153 -18.509,30.428 c -0.211,0.346 -0.195,0.785 0.047,1.109 0.238,0.326 0.65,0.477 1.043,0.381 L -0.763,0.971 C -0.307,0.859 0,0.451 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1172.8843,13.357733)"
+         clip-path="url(#clipPath124)"
+         id="path280" />
+      <path
+         d="m 0,0 c 0,-0.018 0,-0.033 -0.002,-0.051 l -0.793,-15.398 c -0.027,-0.553 -0.498,-0.977 -1.049,-0.948 -0.55,0.03 -1.019,0.467 -0.947,1.049 l 0.668,12.989 -6.305,-5.686 c -0.3,-0.271 -0.734,-0.334 -1.099,-0.16 -0.367,0.172 -0.619,0.556 -0.568,0.953 l 0.872,16.951 c 0.028,0.553 0.498,0.977 1.049,0.947 0.551,-0.027 1.021,-0.426 0.947,-1.049 L -7.975,-4.944 -1.67,0.742 c 0.301,0.272 0.735,0.334 1.1,0.16 C -0.221,0.736 0,0.385 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,425.5692,609.83027)"
+         clip-path="url(#clipPath125)"
+         id="path281" />
+      <path
+         d="m 0,0 c 0,-0.332 -0.166,-0.658 -0.469,-0.847 l -8.095,-5.064 5.889,-1.357 c 0.394,-0.091 0.695,-0.41 0.761,-0.808 0.078,-0.414 -0.111,-0.801 -0.457,-1.014 l -11.161,-6.98 c -0.467,-0.293 -1.084,-0.151 -1.377,0.316 -0.293,0.469 -0.15,1.089 0.318,1.379 l 9.115,5.701 -5.889,1.357 c -0.394,0.092 -0.695,0.411 -0.761,0.809 -0.072,0.412 0.113,0.802 0.457,1.013 L -1.531,0.847 C -1.063,1.141 -0.445,0.998 -0.152,0.531 -0.049,0.365 0,0.182 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1253.2749,147.51467)"
+         clip-path="url(#clipPath126)"
+         id="path282" />
+      <path
+         d="m 0,0 c 0,-0.512 -0.392,-0.949 -0.912,-0.994 l -10.095,-0.89 4.952,-4.15 c 0.308,-0.258 0.429,-0.679 0.31,-1.066 -0.121,-0.385 -0.462,-0.66 -0.865,-0.695 L -20.368,-9.01 c -0.551,-0.049 -1.035,0.358 -1.084,0.908 -0.047,0.529 0.359,1.037 0.908,1.084 l 11.355,1.002 -4.952,4.149 c -0.311,0.256 -0.438,0.674 -0.311,1.066 0.121,0.385 0.463,0.66 0.866,0.695 L -1.088,0.998 C -0.537,1.047 -0.053,0.64 -0.004,0.09 -0.002,0.06 0,0.029 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,265.06693,1163.5099)"
+         clip-path="url(#clipPath127)"
+         id="path283" />
+      <path
+         d="m 0,0 c 0,-0.367 -0.203,-0.721 -0.554,-0.894 -0.495,-0.246 -1.094,-0.045 -1.34,0.449 l -18.578,37.282 -9.13,-27.259 c -0.127,-0.383 -0.475,-0.65 -0.877,-0.68 -0.404,-0.027 -0.785,0.19 -0.965,0.553 l -21.631,43.418 c -0.252,0.488 -0.046,1.093 0.449,1.339 0.494,0.246 1.093,0.045 1.339,-0.449 l 20.556,-41.256 9.131,27.259 c 0.127,0.383 0.474,0.651 0.876,0.68 0.405,0.027 0.785,-0.19 0.965,-0.553 L -0.105,0.445 C -0.033,0.303 0,0.15 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,161.8172,1307.7945)"
+         clip-path="url(#clipPath128)"
+         id="path284" />
+      <path
+         d="m 0,0 c 0,-0.229 -0.078,-0.459 -0.238,-0.648 -0.357,-0.42 -0.988,-0.471 -1.41,-0.114 l -11.745,9.982 0.73,-9.009 c 0.029,-0.397 -0.18,-0.787 -0.539,-0.971 -0.361,-0.183 -0.797,-0.133 -1.105,0.129 l -12.341,10.49 c -0.42,0.357 -0.469,0.988 -0.113,1.41 0.357,0.42 0.988,0.47 1.41,0.113 l 10.501,-8.926 -0.73,9.01 c -0.028,0.386 0.179,0.787 0.539,0.97 0.361,0.184 0.796,0.133 1.105,-0.128 L -0.352,0.761 C -0.119,0.564 0,0.283 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,140.07227,651.6068)"
+         clip-path="url(#clipPath129)"
+         id="path285" />
+      <path
+         d="m 0,0 c 0,-0.434 -0.285,-0.834 -0.723,-0.961 l -14.555,-4.208 8.762,-4.833 c 0.355,-0.195 0.561,-0.58 0.511,-0.986 -0.044,-0.402 -0.328,-0.736 -0.716,-0.849 l -18.572,-5.37 c -0.529,-0.152 -1.084,0.153 -1.238,0.684 -0.158,0.517 0.154,1.083 0.683,1.237 l 16.253,4.7 -8.762,4.833 c -0.353,0.196 -0.555,0.582 -0.512,0.986 0.045,0.403 0.328,0.737 0.717,0.85 L -1.277,0.961 C -0.748,1.113 -0.193,0.809 -0.039,0.277 -0.012,0.186 0,0.092 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,640.1812,995.62427)"
+         clip-path="url(#clipPath130)"
+         id="path286" />
+      <path
+         d="m 0,0 c 0,-0.425 -0.273,-0.82 -0.701,-0.955 -0.527,-0.164 -1.087,0.129 -1.253,0.656 L -5.167,9.992 -7.983,4.622 C -8.17,4.265 -8.554,4.054 -8.957,4.091 -9.359,4.128 -9.701,4.403 -9.822,4.788 l -3.573,11.443 c -0.162,0.539 0.13,1.089 0.656,1.253 0.527,0.164 1.088,-0.128 1.254,-0.656 l 2.852,-9.138 2.814,5.37 c 0.189,0.357 0.574,0.568 0.977,0.531 0.402,-0.037 0.743,-0.313 0.865,-0.697 L -0.045,0.299 C -0.014,0.199 0,0.098 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,524.40307,111.52293)"
+         clip-path="url(#clipPath131)"
+         id="path287" />
+      <path
+         d="m 0,0 c 0,-0.188 -0.052,-0.377 -0.16,-0.543 l -8.529,-13.218 c -0.299,-0.463 -0.918,-0.597 -1.383,-0.297 -0.464,0.299 -0.597,0.922 -0.296,1.383 l 7.22,11.189 -7.519,-1.623 c -0.397,-0.084 -0.803,0.076 -1.033,0.41 -0.231,0.332 -0.236,0.771 -0.018,1.111 l 7.75,12.007 c 0.299,0.463 0.918,0.598 1.383,0.297 0.463,-0.301 0.599,-0.923 0.297,-1.383 l -6.44,-9.978 7.517,1.621 C -0.814,1.062 -0.408,0.902 -0.178,0.568 -0.058,0.398 0,0.199 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,659.9708,654.53573)"
+         clip-path="url(#clipPath132)"
+         id="path288" />
+      <path
+         d="m 0,0 c 0,-0.107 -0.018,-0.217 -0.053,-0.324 -0.179,-0.521 -0.748,-0.801 -1.271,-0.623 l -34.613,11.826 11.083,-22.583 c 0.178,-0.36 0.119,-0.797 -0.148,-1.101 -0.267,-0.305 -0.691,-0.416 -1.072,-0.288 L -66.688,0.779 c -0.525,0.18 -0.793,0.754 -0.625,1.27 0.18,0.523 0.748,0.802 1.27,0.624 l 38.331,-13.092 -11.084,22.583 c -0.173,0.363 -0.117,0.8 0.148,1.101 0.268,0.304 0.692,0.415 1.075,0.287 L -0.675,0.947 C -0.262,0.805 0,0.416 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1117.1628,366.33413)"
+         clip-path="url(#clipPath133)"
+         id="path289" />
+      <path
+         d="M 0,0 C 0,-0.092 -0.014,-0.188 -0.041,-0.281 -0.195,-0.81 -0.75,-1.115 -1.281,-0.959 L -26.603,6.44 -17.98,-9.301 c 0.193,-0.353 0.158,-0.792 -0.098,-1.107 -0.254,-0.314 -0.672,-0.447 -1.06,-0.332 l -30.425,8.887 c -0.529,0.152 -0.837,0.695 -0.677,1.24 0.154,0.529 0.709,0.834 1.24,0.677 l 28.106,-8.208 -8.622,15.74 c -0.194,0.355 -0.157,0.791 0.097,1.107 0.254,0.315 0.672,0.447 1.06,0.332 L -0.719,0.959 C -0.283,0.832 0,0.434 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,565.77387,636.15493)"
+         clip-path="url(#clipPath134)"
+         id="path290" />
+      <path
+         d="m 0,0 c 0,-0.253 -0.096,-0.507 -0.287,-0.701 -0.389,-0.394 -1.021,-0.398 -1.414,-0.012 l -37.013,36.449 0.275,-36.023 v -0.008 c 0,-0.402 -0.24,-0.763 -0.609,-0.922 -0.373,-0.155 -0.804,-0.073 -1.091,0.21 l -42.633,41.984 c -0.394,0.387 -0.398,1.023 -0.012,1.414 0.389,0.394 1.022,0.398 1.414,0.012 l 40.914,-40.292 -0.275,36.023 v 0.008 c 0,0.402 0.24,0.764 0.609,0.921 0.373,0.157 0.805,0.075 1.092,-0.208 L -0.299,0.713 C -0.1,0.517 0,0.258 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,751.2992,953.4856)"
+         clip-path="url(#clipPath135)"
+         id="path291" />
+      <path
+         d="m 0,0 c 0,-0.521 -0.406,-0.961 -0.933,-0.996 -0.553,-0.035 -1.028,0.381 -1.065,0.932 L -2.578,8.754 -6.229,4.587 C -6.495,4.282 -6.918,4.169 -7.301,4.298 c -0.385,0.131 -0.65,0.478 -0.678,0.88 l -0.814,12.357 c -0.043,0.562 0.383,1.029 0.931,1.064 0.551,0.036 1.028,-0.38 1.065,-0.931 l 0.656,-9.949 3.651,4.167 c 0.266,0.304 0.69,0.418 1.072,0.289 0.385,-0.131 0.651,-0.478 0.678,-0.881 L -0.002,0.068 C 0,0.045 0,0.023 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,321.8432,577.69427)"
+         clip-path="url(#clipPath136)"
+         id="path292" />
+      <path
+         d="m 0,0 c 0,-0.387 -0.225,-0.754 -0.603,-0.918 -0.506,-0.219 -1.096,0.014 -1.315,0.522 L -5.878,8.758 -7.92,3.603 C -8.069,3.228 -8.43,2.978 -8.834,2.972 -9.238,2.966 -9.607,3.204 -9.767,3.575 l -4.468,10.33 c -0.223,0.502 0.013,1.092 0.521,1.314 0.506,0.219 1.096,-0.014 1.314,-0.521 l 3.509,-8.113 2.043,5.154 c 0.148,0.375 0.509,0.625 0.914,0.631 0.404,0.006 0.773,-0.232 0.933,-0.603 L -0.082,0.396 C -0.026,0.268 0,0.133 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1170.872,700.55667)"
+         clip-path="url(#clipPath137)"
+         id="path293" />
+      <path
+         d="m 0,0 c 0,-0.215 -0.068,-0.43 -0.209,-0.613 -0.34,-0.436 -0.967,-0.516 -1.404,-0.178 l -42.326,32.819 4.212,-33.28 c 0.053,-0.404 -0.147,-0.794 -0.496,-0.993 -0.352,-0.2 -0.789,-0.17 -1.109,0.077 L -81.52,28.991 c -0.44,0.34 -0.514,0.965 -0.178,1.404 0.34,0.436 0.967,0.516 1.404,0.178 l 38.28,-29.681 -4.212,33.28 c -0.055,0.394 0.147,0.793 0.496,0.993 0.352,0.2 0.789,0.17 1.109,-0.077 L -0.387,0.791 C -0.133,0.593 0,0.297 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,228.75267,451.81173)"
+         clip-path="url(#clipPath138)"
+         id="path294" />
+      <path
+         d="m 0,0 c 0,-0.422 -0.27,-0.816 -0.693,-0.951 -0.526,-0.17 -1.09,0.119 -1.258,0.645 l -9.816,30.495 -8.998,-17.543 c -0.185,-0.36 -0.568,-0.572 -0.972,-0.539 -0.403,0.033 -0.746,0.305 -0.869,0.689 l -9.59,29.79 c -0.166,0.529 0.121,1.092 0.644,1.258 0.526,0.17 1.09,-0.12 1.258,-0.645 l 8.851,-27.493 8.998,17.542 c 0.186,0.36 0.569,0.573 0.973,0.54 0.402,-0.034 0.746,-0.305 0.869,-0.69 L -0.049,0.307 C -0.016,0.205 0,0.102 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1265.9152,418.2104)"
+         clip-path="url(#clipPath139)"
+         id="path295" />
+      <path
+         d="M 0,0 C 0,-0.43 -0.277,-0.824 -0.709,-0.957 L -23.928,-8.039 -9.4,-15.776 c 0.355,-0.189 0.556,-0.573 0.525,-0.978 -0.039,-0.404 -0.318,-0.742 -0.705,-0.861 l -28.099,-8.572 c -0.527,-0.16 -1.086,0.137 -1.248,0.666 -0.16,0.525 0.139,1.083 0.666,1.247 l 25.789,7.868 L -27,-8.67 c -0.355,0.192 -0.542,0.586 -0.525,0.979 0.039,0.404 0.318,0.741 0.705,0.861 L -1.291,0.957 C -0.763,1.117 -0.205,0.82 -0.043,0.291 -0.014,0.196 0,0.096 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,259.87027,95.261067)"
+         clip-path="url(#clipPath140)"
+         id="path296" />
+      <path
+         d="m 0,0 c 0,-0.457 -0.314,-0.869 -0.779,-0.975 l -50.488,-11.468 27.413,-17.265 c 0.342,-0.215 0.519,-0.611 0.453,-1.014 -0.068,-0.398 -0.371,-0.716 -0.765,-0.806 l -48.009,-10.906 c -0.537,-0.123 -1.074,0.215 -1.195,0.754 -0.137,0.537 0.215,1.072 0.754,1.195 l 45.653,10.371 -27.413,17.265 c -0.342,0.215 -0.52,0.613 -0.453,1.014 0.068,0.398 0.371,0.716 0.765,0.806 L -1.221,0.974 C -0.683,1.097 -0.146,0.759 -0.026,0.221 -0.008,0.146 0,0.072 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,204.68787,826.7228)"
+         clip-path="url(#clipPath141)"
+         id="path297" />
+      <path
+         d="m 0,0 c 0,-0.027 0,-0.053 -0.004,-0.08 -0.043,-0.551 -0.523,-0.961 -1.074,-0.918 l -15.545,1.211 5.95,-6.955 c 0.263,-0.305 0.32,-0.741 0.131,-1.104 -0.184,-0.361 -0.565,-0.576 -0.969,-0.542 l -16.311,1.27 c -0.55,0.042 -0.947,0.544 -0.917,1.075 0.043,0.55 0.523,0.96 1.074,0.917 l 13.903,-1.083 -5.95,6.957 c -0.26,0.307 -0.317,0.746 -0.131,1.103 0.184,0.361 0.564,0.576 0.969,0.543 l 17.953,-1.4 C -0.398,0.955 0,0.515 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,302.34213,871.3664)"
+         clip-path="url(#clipPath142)"
+         id="path298" />
+      <path
+         d="M 0,0 C 0,-0.178 -0.047,-0.355 -0.144,-0.518 -0.43,-0.99 -1.045,-1.14 -1.517,-0.855 l -22.938,13.858 3.917,-15.877 c 0.097,-0.396 -0.051,-0.805 -0.377,-1.045 -0.326,-0.24 -0.766,-0.26 -1.111,-0.05 L -44.742,9.756 c -0.472,0.288 -0.619,0.904 -0.338,1.372 0.286,0.473 0.901,0.623 1.373,0.338 l 20.65,-12.477 -3.917,15.877 c -0.1,0.387 0.049,0.802 0.377,1.044 0.326,0.241 0.765,0.26 1.11,0.051 L -0.482,0.855 C -0.172,0.668 0,0.338 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,115.79413,571.06053)"
+         clip-path="url(#clipPath143)"
+         id="path299" />
+      <path
+         d="m 0,0 c 0,-0.221 -0.072,-0.439 -0.215,-0.619 l -7.277,-9.224 c -0.342,-0.434 -0.971,-0.508 -1.404,-0.166 -0.432,0.343 -0.506,0.972 -0.166,1.404 l 5.782,7.33 -5.099,-0.601 c -0.402,-0.049 -0.793,0.15 -0.99,0.503 -0.195,0.352 -0.162,0.791 0.088,1.107 l 6.612,8.381 c 0.342,0.434 0.97,0.508 1.404,0.166 0.435,-0.339 0.507,-0.968 0.166,-1.404 l -5.116,-6.486 5.098,0.601 c 0.402,0.049 0.793,-0.15 0.99,-0.504 C -0.043,0.336 0,0.168 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,105.2184,963.65507)"
+         clip-path="url(#clipPath144)"
+         id="path300" />
+      <path
+         d="m 0,0 c 0,-0.016 0,-0.029 -0.002,-0.045 -0.024,-0.552 -0.492,-0.978 -1.043,-0.953 l -46.28,2.115 21.606,-23.676 c 0.274,-0.299 0.336,-0.732 0.168,-1.098 -0.172,-0.367 -0.549,-0.593 -0.951,-0.574 l -53.595,2.453 c -0.552,0.023 -1.01,0.488 -0.953,1.042 0.023,0.553 0.492,0.979 1.043,0.953 l 51.185,-2.341 -21.606,23.676 c -0.274,0.301 -0.332,0.735 -0.168,1.098 0.172,0.367 0.549,0.593 0.951,0.574 L -0.955,0.998 C -0.418,0.975 0,0.531 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,688.07147,454.54813)"
+         clip-path="url(#clipPath145)"
+         id="path301" />
+      <path
+         d="m 0,0 c 0,-0.504 -0.379,-0.935 -0.892,-0.992 l -44.787,-4.881 24.283,-19.512 c 0.317,-0.251 0.452,-0.667 0.332,-1.06 -0.113,-0.387 -0.449,-0.67 -0.851,-0.713 l -51.939,-5.66 c -0.549,-0.061 -1.041,0.335 -1.101,0.886 -0.043,0.529 0.334,1.041 0.886,1.101 l 49.539,5.399 -24.283,19.512 c -0.314,0.255 -0.439,0.669 -0.332,1.06 0.113,0.387 0.449,0.67 0.852,0.713 L -1.107,0.996 C -0.558,1.057 -0.066,0.66 -0.006,0.11 -0.002,0.074 0,0.037 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,884.1668,930.55333)"
+         clip-path="url(#clipPath146)"
+         id="path302" />
+      <path
+         d="m 0,0 c 0,-0.42 -0.266,-0.811 -0.685,-0.949 l -30.169,-9.99 19.448,-9.773 c 0.362,-0.18 0.574,-0.545 0.549,-0.965 -0.029,-0.404 -0.299,-0.75 -0.684,-0.877 l -35.727,-11.829 c -0.526,-0.174 -1.09,0.111 -1.264,0.635 -0.182,0.517 0.114,1.089 0.635,1.263 l 33.438,11.072 -19.449,9.773 c -0.36,0.181 -0.574,0.557 -0.549,0.964 0.029,0.405 0.299,0.75 0.684,0.877 L -1.314,0.949 C -0.789,1.122 -0.225,0.837 -0.051,0.314 -0.016,0.211 0,0.103 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,366.80413,-1.6025333)"
+         clip-path="url(#clipPath147)"
+         id="path303" />
+      <path
+         d="m 0,0 c 0,-0.496 -0.369,-0.925 -0.875,-0.99 -0.547,-0.068 -1.047,0.319 -1.117,0.867 L -9.505,59.282 -32.547,29.566 c -0.248,-0.319 -0.664,-0.457 -1.054,-0.352 -0.391,0.108 -0.678,0.438 -0.729,0.84 l -7.1,56.147 c -0.07,0.527 0.318,1.047 0.867,1.117 0.547,0.068 1.047,-0.318 1.117,-0.867 L -32.649,32.7 -9.607,62.415 c 0.248,0.319 0.664,0.457 1.054,0.352 0.391,-0.107 0.678,-0.437 0.729,-0.84 l 7.816,-61.8 C -0.002,0.084 0,0.043 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,708.1656,396.9)"
+         clip-path="url(#clipPath148)"
+         id="path304" />
+      <path
+         d="M 0,0 C 0,-0.244 -0.088,-0.488 -0.268,-0.681 -0.643,-1.086 -1.275,-1.109 -1.681,-0.732 L -7.955,5.096 -7.783,0.461 C -7.743,0.076 -8,-0.318 -8.367,-0.486 -8.734,-0.654 -9.168,-0.584 -9.463,-0.309 l -7.309,6.79 c -0.406,0.379 -0.427,1.011 -0.053,1.412 0.376,0.406 1.008,0.429 1.413,0.052 l 5.541,-5.147 -0.172,4.638 c 0.02,0.418 0.217,0.779 0.584,0.947 0.367,0.168 0.801,0.098 1.096,-0.178 L -0.32,0.732 C -0.108,0.535 0,0.268 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,979.26747,589.67067)"
+         clip-path="url(#clipPath149)"
+         id="path305" />
+      <path
+         d="m 0,0 c 0,-0.084 -0.01,-0.17 -0.033,-0.254 -0.141,-0.535 -0.688,-0.853 -1.221,-0.713 l -13.383,3.521 4.575,-7.842 c 0.205,-0.35 0.177,-0.787 -0.066,-1.109 -0.246,-0.322 -0.661,-0.465 -1.051,-0.361 l -17.301,4.552 c -0.535,0.14 -0.855,0.691 -0.713,1.22 0.141,0.535 0.688,0.853 1.221,0.713 l 14.967,-3.937 -4.575,7.842 c -0.205,0.348 -0.178,0.789 0.066,1.109 0.246,0.322 0.66,0.465 1.051,0.361 L -0.746,0.967 C -0.297,0.849 0,0.443 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1137.3821,505.91653)"
+         clip-path="url(#clipPath150)"
+         id="path306" />
+      <path
+         d="m 0,0 c 0,-0.141 -0.029,-0.283 -0.092,-0.418 l -23.223,-50.547 c -0.23,-0.502 -0.824,-0.72 -1.326,-0.49 -0.502,0.23 -0.72,0.822 -0.49,1.326 L -2.915,-1.777 -37.536,-14.6 c -0.379,-0.141 -0.807,-0.039 -1.082,0.257 -0.273,0.299 -0.347,0.725 -0.174,1.098 l 25.561,55.638 c 0.23,0.501 0.824,0.72 1.326,0.49 0.502,-0.231 0.718,-0.824 0.49,-1.326 L -35.968,-11.886 -1.347,0.937 C -0.969,1.078 -0.541,0.976 -0.266,0.679 -0.092,0.49 0,0.246 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,620.82627,171.87333)"
+         clip-path="url(#clipPath151)"
+         id="path307" />
+      <path
+         d="m 0,0 c 0,-0.088 -0.012,-0.18 -0.037,-0.27 -0.149,-0.533 -0.701,-0.841 -1.232,-0.693 l -31.274,8.77 10.905,-19.406 c 0.199,-0.349 0.166,-0.789 -0.084,-1.107 -0.25,-0.319 -0.668,-0.455 -1.056,-0.346 l -36.984,10.371 c -0.527,0.15 -0.836,0.705 -0.693,1.232 0.148,0.533 0.701,0.842 1.232,0.693 l 34.66,-9.718 -10.906,19.406 c -0.195,0.353 -0.164,0.79 0.084,1.106 0.25,0.319 0.668,0.456 1.057,0.346 L -0.73,0.963 C -0.289,0.839 0,0.437 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1142.9408,274.31853)"
+         clip-path="url(#clipPath152)"
+         id="path308" />
+      <path
+         d="m 0,0 c 0,-0.395 -0.234,-0.767 -0.623,-0.926 -0.512,-0.208 -1.095,0.037 -1.302,0.549 l -9.104,22.348 -5.68,-13.491 c -0.156,-0.373 -0.523,-0.613 -0.927,-0.611 -0.405,0.002 -0.768,0.248 -0.92,0.623 l -9.098,22.335 c -0.211,0.507 0.037,1.093 0.549,1.302 0.511,0.209 1.095,-0.037 1.303,-0.549 l 8.187,-20.098 5.68,13.491 c 0.159,0.373 0.524,0.613 0.928,0.611 0.404,-0.002 0.767,-0.248 0.919,-0.623 L -0.074,0.377 C -0.023,0.254 0,0.127 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1109.3624,851.22493)"
+         clip-path="url(#clipPath153)"
+         id="path309" />
+      <path
+         d="m 0,0 c 0,-0.267 -0.106,-0.533 -0.316,-0.731 l -35.355,-33.056 30.211,-1.014 c 0.405,-0.013 0.762,-0.269 0.903,-0.648 0.142,-0.383 0.042,-0.805 -0.252,-1.082 l -33.721,-31.53 c -0.404,-0.377 -1.037,-0.355 -1.414,0.047 -0.375,0.406 -0.355,1.037 0.047,1.414 l 31.958,29.882 -30.212,1.013 c -0.405,0.014 -0.762,0.27 -0.902,0.648 -0.141,0.383 -0.044,0.805 0.251,1.082 L -1.683,0.73 C -1.279,1.107 -0.646,1.085 -0.27,0.683 -0.09,0.49 0,0.244 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,800.16533,424.80987)"
+         clip-path="url(#clipPath154)"
+         id="path310" />
+      <path
+         d="M 0,0 V -0.039 C -0.023,-0.592 -0.488,-1.021 -1.039,-1 l -46.622,1.863 21.899,-23.723 c 0.274,-0.295 0.344,-0.73 0.174,-1.097 -0.17,-0.367 -0.545,-0.596 -0.947,-0.58 l -53.97,2.155 c -0.55,0.022 -0.963,0.487 -0.961,1.039 0.024,0.553 0.489,0.982 1.039,0.961 l 51.559,-2.06 -21.9,23.723 c -0.275,0.297 -0.345,0.732 -0.173,1.097 0.169,0.367 0.545,0.596 0.947,0.58 L -0.961,1 C -0.422,0.978 0,0.535 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,410.65587,192.54053)"
+         clip-path="url(#clipPath155)"
+         id="path311" />
+      <path
+         d="M 0,0 C 0,-0.082 -0.01,-0.162 -0.029,-0.244 L -5.5,-21.977 c -0.137,-0.535 -0.68,-0.862 -1.215,-0.727 -0.533,0.135 -0.853,0.672 -0.726,1.215 l 4.883,19.392 -10.287,-6.148 c -0.347,-0.208 -0.785,-0.185 -1.109,0.055 -0.326,0.243 -0.47,0.664 -0.375,1.047 l 4.972,19.745 c 0.137,0.535 0.679,0.862 1.214,0.727 0.536,-0.137 0.858,-0.679 0.727,-1.215 L -11.8,-5.29 -1.513,0.857 C -1.166,1.066 -0.728,1.043 -0.404,0.803 -0.146,0.611 0,0.31 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,154.08453,151.69827)"
+         clip-path="url(#clipPath156)"
+         id="path312" />
+      <path
+         d="m 0,0 c 0,-0.096 -0.014,-0.196 -0.043,-0.293 -0.162,-0.527 -0.72,-0.824 -1.25,-0.664 l -7.843,2.398 2.392,-4.499 c 0.189,-0.355 0.144,-0.791 -0.112,-1.105 -0.258,-0.311 -0.677,-0.438 -1.064,-0.32 l -11.177,3.415 c -0.525,0.162 -0.824,0.714 -0.664,1.25 0.162,0.527 0.721,0.823 1.25,0.663 l 8.867,-2.71 -2.392,4.499 c -0.19,0.355 -0.145,0.793 0.111,1.105 0.258,0.311 0.678,0.438 1.064,0.32 L -0.707,0.957 C -0.277,0.824 0,0.427 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,917.5756,23.285067)"
+         clip-path="url(#clipPath157)"
+         id="path313" />
+    </g>
+    <g
+       opacity="0.300003"
+       id="g618"
+       clip-path="url(#clipPath619)">
+      <path
+         d="M 0,0 12.476,0.97 5.399,11.29 Z m 15.28,0.107 c 0,-0.146 -0.034,-0.295 -0.098,-0.431 -0.154,-0.323 -0.469,-0.537 -0.824,-0.565 l -15.93,-1.238 c -0.357,-0.029 -0.701,0.137 -0.902,0.43 -0.203,0.295 -0.23,0.674 -0.078,0.998 l 6.895,14.415 c 0.154,0.322 0.469,0.536 0.824,0.564 0.357,0.029 0.701,-0.137 0.902,-0.43 L 15.104,0.674 C 15.221,0.503 15.28,0.306 15.28,0.107"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1637.0976,506.72867)"
+         clip-path="url(#clipPath315)"
+         id="path467" />
+      <path
+         d="m 0,0 7.766,4.806 -8.043,4.321 z m 10.763,4.866 c 0,-0.345 -0.177,-0.668 -0.474,-0.849 L -0.422,-2.611 c -0.302,-0.189 -0.683,-0.201 -0.997,-0.031 -0.317,0.17 -0.516,0.494 -0.528,0.85 l -0.382,12.588 c 0,0.446 0.171,0.696 0.474,0.881 0.303,0.189 0.684,0.201 0.998,0.032 L 10.236,5.747 c 0.316,-0.17 0.515,-0.494 0.527,-0.85 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1989.3265,700.7444)"
+         clip-path="url(#clipPath316)"
+         id="path468" />
+      <path
+         d="M 0,0 45.494,7.34 16.389,43.068 Z M 48.362,6.629 C 48.362,6.51 48.34,6.389 48.298,6.274 48.169,5.94 47.874,5.7 47.522,5.643 L -1.39,-2.249 c -0.354,-0.059 -0.709,0.077 -0.935,0.355 -0.225,0.273 -0.288,0.65 -0.16,0.986 l 17.62,46.306 c 0.129,0.334 0.424,0.574 0.776,0.63 0.353,0.059 0.708,-0.078 0.935,-0.355 L 48.138,7.26 c 0.148,-0.18 0.224,-0.404 0.224,-0.631"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2519.0484,207.4172)"
+         clip-path="url(#clipPath317)"
+         id="path469" />
+      <path
+         d="m 0,0 18.402,-2.896 -6.694,17.383 z m 20.956,-4.153 c 0,-0.225 -0.076,-0.447 -0.222,-0.629 -0.225,-0.278 -0.58,-0.414 -0.934,-0.36 l -21.823,3.435 c -0.351,0.057 -0.648,0.295 -0.777,0.629 -0.127,0.336 -0.07,0.709 0.156,0.988 l 13.886,17.182 c 0.224,0.277 0.58,0.414 0.933,0.359 0.352,-0.057 0.648,-0.295 0.777,-0.629 L 20.89,-3.794 c 0.045,-0.117 0.066,-0.238 0.066,-0.359"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1805.7671,1228.9636)"
+         clip-path="url(#clipPath318)"
+         id="path470" />
+      <path
+         d="M 0,0 13.559,-3.316 9.65,10.083 Z m 16.004,-4.699 c 0,-0.253 -0.098,-0.501 -0.277,-0.691 -0.248,-0.257 -0.613,-0.365 -0.961,-0.279 l -16.924,4.138 c -0.345,0.084 -0.621,0.348 -0.723,0.691 -0.093,0.338 -0.007,0.709 0.239,0.971 L 9.402,12.717 c 0.248,0.258 0.613,0.366 0.961,0.28 0.345,-0.084 0.62,-0.348 0.722,-0.691 l 4.88,-16.725 c 0.025,-0.092 0.039,-0.186 0.039,-0.28"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2205.5845,843.09133)"
+         clip-path="url(#clipPath319)"
+         id="path471" />
+      <path
+         d="m 0,0 6.973,17.117 -18.31,-2.519 z m 9.553,18.343 c 0,-0.126 -0.024,-0.256 -0.075,-0.376 L 1.199,-2.357 C 1.064,-2.689 0.763,-2.921 0.41,-2.97 0.057,-3.019 -0.297,-2.877 -0.516,-2.593 l -13.461,17.332 c -0.219,0.277 -0.277,0.656 -0.137,0.99 0.135,0.332 0.436,0.564 0.789,0.613 L 8.416,19.334 C 8.77,19.382 9.123,19.24 9.341,18.956 9.48,18.779 9.553,18.562 9.553,18.343"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1710.8645,940.87627)"
+         clip-path="url(#clipPath320)"
+         id="path472" />
+      <path
+         d="m 0,0 20.927,37.46 -42.906,-0.607 z m 23.643,38.485 c 0,-0.168 -0.043,-0.336 -0.127,-0.488 L 0.9,-2.488 c -0.173,-0.31 -0.502,-0.506 -0.859,-0.511 -0.357,-0.006 -0.689,0.181 -0.873,0.488 l -23.752,39.826 c -0.184,0.303 -0.188,0.686 -0.014,1 0.174,0.311 0.502,0.506 0.859,0.512 l 46.369,0.658 c 0.357,0.006 0.689,-0.182 0.873,-0.488 0.093,-0.156 0.14,-0.334 0.14,-0.512"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1965.8476,1134.2717)"
+         clip-path="url(#clipPath321)"
+         id="path473" />
+      <path
+         d="M 0,0 6.397,1.195 2.165,6.137 Z m 9.283,0.529 c 0,-0.111 -0.02,-0.225 -0.056,-0.332 -0.12,-0.338 -0.409,-0.586 -0.76,-0.65 l -9.803,-1.83 c -0.351,-0.066 -0.71,0.061 -0.943,0.332 -0.236,0.27 -0.3,0.645 -0.183,0.982 L 0.855,8.433 C 0.974,8.771 1.263,9.019 1.615,9.084 1.966,9.15 2.326,9.023 2.558,8.752 L 9.043,1.179 c 0.158,-0.183 0.24,-0.416 0.24,-0.65"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2034.2745,291.3536)"
+         clip-path="url(#clipPath322)"
+         id="path474" />
+      <path
+         d="m 0,0 10.832,28.269 -29.898,-4.753 z m 13.384,29.528 c 0,-0.121 -0.022,-0.242 -0.067,-0.357 L 1.248,-2.331 C 1.121,-2.665 0.824,-2.906 0.471,-2.962 0.119,-3.017 -0.238,-2.882 -0.463,-2.603 L -21.71,23.602 c -0.226,0.275 -0.289,0.652 -0.156,0.986 0.127,0.334 0.424,0.574 0.777,0.631 l 33.317,5.298 c 0.351,0.054 0.707,-0.081 0.933,-0.36 0.147,-0.179 0.223,-0.402 0.223,-0.629"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1453.0072,1244.52)"
+         clip-path="url(#clipPath323)"
+         id="path475" />
+      <path
+         d="M 0,0 1.681,12.433 -9.925,7.67 Z M 3.904,14.014 C 3.904,13.97 3.9,13.924 3.894,13.88 L 1.75,-1.984 C 1.703,-2.337 1.47,-2.638 1.139,-2.775 0.809,-2.91 0.432,-2.859 0.148,-2.64 l -12.667,9.787 c -0.281,0.219 -0.431,0.57 -0.378,0.925 0.046,0.354 0.279,0.654 0.611,0.791 L 2.525,14.94 c 0.33,0.135 0.707,0.084 0.99,-0.135 0.246,-0.191 0.389,-0.484 0.389,-0.791"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2129.8125,1256.2933)"
+         clip-path="url(#clipPath324)"
+         id="path476" />
+      <path
+         d="M 0,0 22.208,3.589 7.994,21.028 Z m 25.076,2.878 c 0,-0.119 -0.021,-0.24 -0.064,-0.355 C 24.885,2.189 24.588,1.949 24.237,1.892 L -1.39,-2.249 c -0.354,-0.059 -0.709,0.077 -0.935,0.355 -0.227,0.273 -0.288,0.65 -0.161,0.986 l 9.227,24.266 c 0.127,0.334 0.423,0.574 0.775,0.63 0.353,0.059 0.709,-0.077 0.935,-0.355 L 24.852,3.509 C 25,3.329 25.076,3.105 25.076,2.878"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1310.5087,335.86173)"
+         clip-path="url(#clipPath325)"
+         id="path477" />
+      <path
+         d="M 0,0 0.974,14.22 -11.829,7.951 Z m 3.089,15.879 c 0,-0.023 0,-0.045 -0.002,-0.068 L 1.876,-1.865 C 1.851,-2.22 1.638,-2.537 1.318,-2.695 0.998,-2.851 0.617,-2.825 0.32,-2.626 l -14.704,9.884 c -0.296,0.201 -0.482,0.523 -0.439,0.898 0.026,0.356 0.238,0.672 0.559,0.83 L 1.65,16.777 c 0.32,0.157 0.701,0.131 0.998,-0.068 0.277,-0.187 0.441,-0.498 0.441,-0.83"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1442.1377,32.1348)"
+         clip-path="url(#clipPath326)"
+         id="path478" />
+      <path
+         d="M 0,0 6.635,1.668 1.872,6.58 Z M 9.558,1.121 C 9.558,1.029 9.547,0.937 9.519,0.847 9.422,0.503 9.148,0.238 8.802,0.15 l -9.993,-2.513 c -0.348,-0.086 -0.713,0.018 -0.963,0.275 -0.248,0.254 -0.347,0.631 -0.242,0.969 l 2.82,9.912 C 0.521,9.136 0.795,9.402 1.14,9.49 1.486,9.576 1.853,9.472 2.103,9.215 L 9.277,1.816 C 9.459,1.628 9.558,1.376 9.558,1.121"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1371.508,855.26827)"
+         clip-path="url(#clipPath327)"
+         id="path479" />
+      <path
+         d="m 0,0 11.097,33.258 -34.351,-7.02 z m 13.593,34.584 c 0,-0.106 -0.018,-0.213 -0.051,-0.317 L 1.349,-2.275 c -0.113,-0.34 -0.398,-0.592 -0.75,-0.664 -0.349,-0.07 -0.71,0.051 -0.947,0.316 l -25.55,28.83 c -0.237,0.267 -0.311,0.646 -0.202,0.98 0.114,0.34 0.399,0.591 0.748,0.664 l 37.744,7.713 c 0.351,0.07 0.713,-0.051 0.949,-0.316 0.164,-0.186 0.252,-0.424 0.252,-0.664"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2221.9711,1082.4816)"
+         clip-path="url(#clipPath328)"
+         id="path480" />
+      <path
+         d="M 0,0 4.853,5.088 -1.98,6.746 Z M 7.77,5.651 C 7.77,5.397 7.674,5.149 7.495,4.962 L 0.252,-2.632 c -0.248,-0.26 -0.613,-0.367 -0.961,-0.284 -0.347,0.086 -0.623,0.348 -0.722,0.692 l -2.954,10.07 c -0.1,0.341 -0.014,0.712 0.236,0.97 0.246,0.26 0.611,0.367 0.959,0.283 L 7.006,6.623 C 7.354,6.537 7.63,6.276 7.729,5.932 7.756,5.84 7.77,5.745 7.77,5.651"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1733.2056,1261.1957)"
+         clip-path="url(#clipPath329)"
+         id="path481" />
+      <path
+         d="M 0,0 36.874,8.424 11.142,36.148 Z M 39.786,7.834 C 39.786,7.736 39.772,7.637 39.741,7.539 39.635,7.198 39.356,6.94 39.009,6.86 L -1.244,-2.335 c -0.348,-0.08 -0.713,0.033 -0.955,0.294 -0.244,0.26 -0.336,0.623 -0.223,0.975 L 9.742,38.392 c 0.105,0.341 0.384,0.599 0.732,0.679 0.348,0.08 0.713,-0.033 0.955,-0.295 L 39.518,8.514 c 0.174,-0.188 0.268,-0.432 0.268,-0.68"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1388.0301,1150.3151)"
+         clip-path="url(#clipPath330)"
+         id="path482" />
+      <path
+         d="M 0,0 37.052,-9.119 26.424,27.529 Z m 39.495,-10.503 c 0,-0.254 -0.098,-0.504 -0.28,-0.694 -0.246,-0.257 -0.613,-0.363 -0.958,-0.277 l -40.415,9.947 c -0.347,0.086 -0.623,0.35 -0.722,0.692 -0.094,0.339 -0.008,0.71 0.24,0.972 l 28.821,30.026 c 0.246,0.258 0.614,0.363 0.959,0.278 0.348,-0.086 0.623,-0.35 0.722,-0.692 l 11.594,-39.973 c 0.025,-0.092 0.039,-0.186 0.039,-0.279"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2491.1177,874.01427)"
+         clip-path="url(#clipPath331)"
+         id="path483" />
+      <path
+         d="M 0,0 7.389,-0.998 4.557,5.899 Z M 9.97,-2.22 C 9.97,-2.437 9.9,-2.653 9.761,-2.831 9.543,-3.114 9.191,-3.259 8.836,-3.21 l -10.818,1.46 c -0.356,0.047 -0.656,0.28 -0.793,0.612 -0.131,0.326 -0.086,0.705 0.135,0.99 L 4.034,8.493 C 4.253,8.776 4.604,8.92 4.958,8.871 5.313,8.824 5.614,8.592 5.751,8.26 L 9.896,-1.841 C 9.945,-1.962 9.97,-2.091 9.97,-2.22"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2474.3141,777.19027)"
+         clip-path="url(#clipPath332)"
+         id="path484" />
+      <path
+         d="m 0,0 9.422,18.492 -20.726,-1.09 z m 12.099,19.581 c 0,-0.155 -0.035,-0.31 -0.11,-0.452 L 0.996,-2.45 c -0.162,-0.319 -0.48,-0.528 -0.838,-0.545 -0.357,-0.02 -0.697,0.154 -0.89,0.453 l -13.191,20.308 c -0.195,0.304 -0.217,0.683 -0.052,0.997 0.162,0.319 0.48,0.528 0.837,0.545 l 24.184,1.271 c 0.357,0.02 0.697,-0.154 0.891,-0.452 0.107,-0.166 0.162,-0.356 0.162,-0.546"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1435.4437,704.92307)"
+         clip-path="url(#clipPath333)"
+         id="path485" />
+      <path
+         d="M 0,0 56.383,11.784 17.986,54.72 Z m 59.283,11.159 c 0,-0.105 -0.015,-0.208 -0.051,-0.312 -0.111,-0.34 -0.394,-0.593 -0.744,-0.666 L -1.285,-2.312 c -0.349,-0.074 -0.713,0.045 -0.951,0.312 -0.24,0.264 -0.322,0.641 -0.203,0.979 l 19.066,58.01 c 0.111,0.34 0.394,0.593 0.744,0.666 0.349,0.074 0.712,-0.045 0.951,-0.313 L 59.029,11.825 c 0.166,-0.185 0.254,-0.423 0.254,-0.666"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1411.9675,170.01453)"
+         clip-path="url(#clipPath334)"
+         id="path486" />
+      <path
+         d="m 0,0 45.3,-24.678 -1.277,51.572 z m 47.342,-26.385 c 0,-0.347 -0.181,-0.672 -0.478,-0.853 -0.305,-0.186 -0.685,-0.195 -1,-0.025 L -2.478,-0.928 c -0.315,0.172 -0.512,0.497 -0.521,0.854 -0.04,0.439 0.173,0.693 0.478,0.878 l 46.979,28.699 c 0.305,0.185 0.686,0.195 1,0.025 0.315,-0.171 0.512,-0.496 0.521,-0.853 l 1.363,-55.034 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2037.8001,742.25)"
+         clip-path="url(#clipPath335)"
+         id="path487" />
+      <path
+         d="M 0,0 9.652,-2.158 6.696,7.28 Z m 12.124,-3.511 c 0,-0.248 -0.092,-0.49 -0.263,-0.678 -0.242,-0.261 -0.606,-0.376 -0.955,-0.298 l -13.032,2.913 c -0.348,0.078 -0.629,0.336 -0.737,0.678 -0.099,0.341 -0.023,0.714 0.219,0.976 L 6.395,9.908 C 6.637,10.17 7,10.285 7.35,10.207 7.697,10.128 7.979,9.871 8.086,9.529 l 3.993,-12.741 c 0.03,-0.098 0.045,-0.199 0.045,-0.299"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2541.8452,89.6112)"
+         clip-path="url(#clipPath336)"
+         id="path488" />
+      <path
+         d="m 0,0 7.85,6.009 -9.129,3.794 z m 10.832,6.266 c 0,-0.308 -0.143,-0.603 -0.393,-0.794 L -0.16,-2.642 c -0.283,-0.217 -0.662,-0.265 -0.99,-0.129 -0.33,0.137 -0.562,0.44 -0.61,0.795 l -1.728,13.237 c -0.048,0.352 0.102,0.707 0.385,0.924 0.283,0.217 0.662,0.265 0.992,0.129 L 10.216,7.19 c 0.328,-0.137 0.561,-0.44 0.607,-0.795 0.006,-0.043 0.009,-0.086 0.009,-0.129"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2093.7376,945.23747)"
+         clip-path="url(#clipPath337)"
+         id="path489" />
+      <path
+         d="m 0,0 47.505,-20.417 -6.071,51.349 z m 49.701,-22.021 c 0,-0.312 -0.146,-0.611 -0.402,-0.8 -0.285,-0.215 -0.664,-0.26 -0.992,-0.117 L -2.381,-1.152 c -0.328,0.141 -0.556,0.445 -0.597,0.8 -0.051,0.354 0.107,0.706 0.395,0.918 L 41.625,33.57 c 0.285,0.215 0.664,0.26 0.992,0.117 0.328,-0.14 0.557,-0.445 0.597,-0.8 l 6.479,-54.79 c 0.006,-0.039 0.008,-0.078 0.008,-0.118"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2267.9243,332.83893)"
+         clip-path="url(#clipPath338)"
+         id="path490" />
+      <path
+         d="M 0,0 34.051,11.161 7.358,35.07 Z M 37.007,10.752 C 37.007,10.683 37,10.615 36.986,10.546 36.913,10.197 36.658,9.912 36.318,9.801 L -1.023,-2.441 c -0.338,-0.111 -0.711,-0.031 -0.979,0.207 -0.263,0.238 -0.382,0.602 -0.31,0.949 l 8.069,38.46 c 0.072,0.35 0.328,0.635 0.665,0.746 0.34,0.111 0.713,0.031 0.981,-0.207 L 36.675,11.495 c 0.213,-0.191 0.332,-0.462 0.332,-0.743"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1508.2159,83.055333)"
+         clip-path="url(#clipPath339)"
+         id="path491" />
+      <path
+         d="M 0,0 39.454,9.664 11.357,39.001 Z m 42.373,9.106 c 0,-0.094 -0.014,-0.188 -0.039,-0.28 C 42.232,8.482 41.957,8.219 41.611,8.135 L -1.207,-2.353 c -0.347,-0.086 -0.713,0.022 -0.96,0.279 -0.247,0.258 -0.334,0.629 -0.239,0.971 L 9.919,41.223 c 0.102,0.344 0.377,0.607 0.723,0.691 0.348,0.086 0.713,-0.021 0.961,-0.279 L 42.095,9.797 c 0.18,-0.188 0.278,-0.438 0.278,-0.691"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2011.6056,1334.2157)"
+         clip-path="url(#clipPath340)"
+         id="path492" />
+      <path
+         d="M 0,0 8.004,14.784 -8.802,14.323 Z m 10.707,15.83 c 0,-0.164 -0.041,-0.328 -0.121,-0.476 L 0.933,-2.476 C 0.764,-2.791 0.44,-2.99 0.082,-2.999 c -0.357,-0.01 -0.691,0.172 -0.879,0.476 l -10.616,17.274 c -0.187,0.306 -0.197,0.687 -0.028,0.999 0.17,0.315 0.494,0.514 0.852,0.523 L 9.68,16.83 c 0.357,0.01 0.691,-0.172 0.878,-0.476 0.1,-0.161 0.149,-0.342 0.149,-0.524"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1628.5864,1063.8507)"
+         clip-path="url(#clipPath341)"
+         id="path493" />
+      <path
+         d="M 0,0 5.686,-3.034 5.472,3.408 Z m 7.742,-4.731 c 0,-0.344 -0.177,-0.666 -0.47,-0.85 -0.305,-0.187 -0.686,-0.201 -1,-0.033 l -8.74,4.665 c -0.315,0.168 -0.518,0.492 -0.529,0.849 0,0.325 0.168,0.694 0.47,0.883 l 8.41,5.237 c 0.305,0.188 0.686,0.201 1,0.033 C 7.198,5.885 7.401,5.562 7.412,5.204 l 0.33,-9.902 z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2540.4968,526.93787)"
+         clip-path="url(#clipPath342)"
+         id="path494" />
+      <path
+         d="m 0,0 8.211,5.011 -8.445,4.606 z m 11.21,5.06 c 0,-0.348 -0.181,-0.672 -0.478,-0.854 L -0.436,-2.609 c -0.304,-0.185 -0.687,-0.195 -0.999,-0.025 -0.315,0.172 -0.512,0.498 -0.522,0.855 L -2.275,11.3 c 0.027,0.352 0.176,0.692 0.479,0.877 0.304,0.185 0.687,0.195 0.999,0.023 L 10.689,5.936 C 11.003,5.766 11.201,5.44 11.21,5.083 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2118.4845,842.35493)"
+         clip-path="url(#clipPath343)"
+         id="path495" />
+      <path
+         d="M 0,0 41.113,20.778 2.562,45.995 Z m 44.109,20.667 c 0,-0.018 0,-0.037 -0.002,-0.055 -0.02,-0.357 -0.229,-0.675 -0.547,-0.837 L -0.645,-2.566 c -0.318,-0.16 -0.699,-0.141 -0.997,0.057 -0.299,0.191 -0.502,0.527 -0.452,0.89 l 2.756,49.454 c 0.019,0.357 0.228,0.675 0.546,0.837 0.319,0.16 0.7,0.141 0.998,-0.056 l 41.45,-27.113 c 0.283,-0.184 0.453,-0.5 0.453,-0.836"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1312.2092,83.047333)"
+         clip-path="url(#clipPath344)"
+         id="path496" />
+      <path
+         d="m 0,0 15.319,10.597 -16.836,7.967 z m 18.312,10.759 c 0,-0.326 -0.16,-0.634 -0.431,-0.822 L -0.287,-2.63 c -0.293,-0.203 -0.674,-0.234 -0.996,-0.082 -0.322,0.152 -0.539,0.467 -0.568,0.822 l -1.8,22.016 c -0.035,0.361 0.133,0.701 0.427,0.904 0.293,0.204 0.674,0.235 0.996,0.082 L 17.74,11.663 c 0.322,-0.152 0.539,-0.466 0.569,-0.822 0.002,-0.027 0.003,-0.055 0.003,-0.082"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1313.8803,813.70493)"
+         clip-path="url(#clipPath345)"
+         id="path497" />
+      <path
+         d="m 0,0 7.321,0.299 -3.919,6.19 z m 10.091,-0.629 c 0,-0.158 -0.036,-0.318 -0.115,-0.465 C 9.812,-1.41 9.49,-1.613 9.133,-1.629 L -1.648,-2.07 c -0.357,-0.014 -0.695,0.164 -0.887,0.465 -0.189,0.298 -0.21,0.679 -0.038,1 L 2.435,8.951 C 2.599,9.267 2.921,9.47 3.279,9.486 3.636,9.499 3.974,9.322 4.165,9.021 l 5.772,-9.115 c 0.102,-0.162 0.154,-0.349 0.154,-0.535"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1308.2905,1150.2004)"
+         clip-path="url(#clipPath346)"
+         id="path498" />
+      <path
+         d="m 0,0 9.246,35.258 -35.158,-9.623 z m 11.652,36.679 c 0,-0.084 -0.01,-0.17 -0.033,-0.254 L 1.494,-2.183 C 1.404,-2.529 1.137,-2.8 0.791,-2.894 0.447,-2.988 0.078,-2.892 -0.176,-2.64 l -28.372,28.072 c -0.254,0.25 -0.359,0.617 -0.264,0.964 0.09,0.346 0.358,0.617 0.703,0.711 l 38.497,10.537 c 0.344,0.093 0.713,-0.002 0.967,-0.254 0.193,-0.189 0.297,-0.447 0.297,-0.711"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1643.8539,76.392933)"
+         clip-path="url(#clipPath347)"
+         id="path499" />
+      <path
+         d="m 0,0 1.261,19.97 -17.925,-8.893 z m 3.369,21.636 c 0,-0.022 0,-0.041 -0.003,-0.063 L 1.886,-1.853 C 1.863,-2.21 1.652,-2.527 1.334,-2.687 1.013,-2.845 0.633,-2.822 0.336,-2.622 l -19.548,12.995 c -0.299,0.199 -0.461,0.541 -0.446,0.894 0.024,0.357 0.235,0.673 0.553,0.834 L 1.923,22.532 c 0.321,0.158 0.701,0.135 0.998,-0.064 0.282,-0.186 0.448,-0.498 0.448,-0.832"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1776.7689,780.05147)"
+         clip-path="url(#clipPath348)"
+         id="path500" />
+      <path
+         d="m 0,0 24.371,50.06 -55.538,-3.924 z m 27.029,51.179 c 0,-0.148 -0.033,-0.298 -0.102,-0.437 L 1.039,-2.431 C 0.883,-2.753 0.568,-2.966 0.211,-2.992 -0.145,-3.017 -0.488,-2.849 -0.687,-2.554 L -33.793,46.45 c -0.199,0.299 -0.229,0.678 -0.07,0.998 0.156,0.322 0.47,0.535 0.827,0.56 l 58.995,4.169 c 0.355,0.026 0.699,-0.142 0.898,-0.437 0.113,-0.17 0.172,-0.365 0.172,-0.561"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2493.5833,17.994533)"
+         clip-path="url(#clipPath349)"
+         id="path501" />
+      <path
+         d="m 0,0 3.206,9.513 -9.843,-1.98 z m 5.706,10.836 c 0,-0.108 -0.018,-0.215 -0.053,-0.319 L 1.341,-2.279 c -0.113,-0.34 -0.4,-0.592 -0.749,-0.662 -0.35,-0.07 -0.711,0.051 -0.947,0.32 L -9.281,7.512 c -0.238,0.265 -0.314,0.639 -0.198,0.98 0.114,0.338 0.401,0.59 0.75,0.66 l 13.238,2.664 c 0.349,0.07 0.71,-0.051 0.947,-0.321 0.164,-0.183 0.25,-0.42 0.25,-0.659"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1923.4253,420.22)"
+         clip-path="url(#clipPath350)"
+         id="path502" />
+      <path
+         d="M 0,0 12.204,3.066 3.446,12.103 Z M 15.127,2.517 C 15.127,2.425 15.116,2.333 15.088,2.244 14.991,1.9 14.717,1.634 14.371,1.547 l -15.562,-3.91 c -0.348,-0.086 -0.713,0.018 -0.963,0.276 -0.246,0.253 -0.349,0.629 -0.242,0.969 L 2,14.315 c 0.097,0.344 0.37,0.61 0.716,0.697 0.348,0.086 0.713,-0.017 0.963,-0.275 L 14.846,3.213 c 0.184,-0.19 0.281,-0.44 0.281,-0.696"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1547.6653,460.22147)"
+         clip-path="url(#clipPath351)"
+         id="path503" />
+      <path
+         d="M 0,0 20.62,6.35 4.808,21.032 Z M 23.569,5.905 C 23.569,5.831 23.561,5.756 23.543,5.682 23.463,5.335 23.206,5.055 22.864,4.95 l -23.93,-7.369 c -0.342,-0.106 -0.713,-0.022 -0.974,0.222 -0.262,0.244 -0.379,0.609 -0.295,0.955 l 5.581,24.408 c 0.08,0.348 0.337,0.627 0.679,0.733 0.342,0.105 0.713,0.021 0.974,-0.223 L 23.249,6.637 c 0.207,-0.191 0.32,-0.457 0.32,-0.732"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1497.4188,755.0284)"
+         clip-path="url(#clipPath352)"
+         id="path504" />
+      <path
+         d="m 0,0 16.029,-6.626 -2.275,17.194 z m 18.247,-8.211 c 0,-0.309 -0.142,-0.601 -0.39,-0.793 -0.283,-0.217 -0.662,-0.267 -0.992,-0.131 l -19.23,7.95 c -0.33,0.136 -0.562,0.437 -0.609,0.792 -0.049,0.358 0.101,0.707 0.383,0.924 l 16.5,12.677 c 0.283,0.217 0.662,0.267 0.992,0.131 0.329,-0.137 0.562,-0.438 0.609,-0.793 L 18.24,-8.08 c 0.006,-0.043 0.007,-0.088 0.007,-0.131"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1892.3467,1241.2056)"
+         clip-path="url(#clipPath353)"
+         id="path505" />
+      <path
+         d="M 0,0 32.03,20.991 -2.163,38.234 Z m 35.025,21.105 c 0,-0.336 -0.168,-0.651 -0.451,-0.836 L -0.352,-2.621 c -0.298,-0.197 -0.679,-0.218 -0.999,-0.056 -0.319,0.16 -0.527,0.478 -0.547,0.836 l -2.359,41.689 c -0.033,0.37 0.148,0.695 0.449,0.893 0.299,0.197 0.68,0.218 1,0.056 l 37.284,-18.8 c 0.319,-0.16 0.528,-0.478 0.547,-0.836 0.002,-0.019 0.002,-0.037 0.002,-0.056"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2202.7568,1264.1197)"
+         clip-path="url(#clipPath354)"
+         id="path506" />
+      <path
+         d="M 0,0 25.65,3.206 10.048,23.817 Z M 28.491,2.429 C 28.491,2.298 28.466,2.165 28.413,2.04 28.275,1.71 27.97,1.482 27.616,1.437 L -1.469,-2.199 c -0.355,-0.045 -0.707,0.103 -0.921,0.389 -0.217,0.283 -0.264,0.66 -0.125,0.992 L 8.879,26.189 c 0.138,0.33 0.443,0.558 0.796,0.604 0.356,0.044 0.707,-0.104 0.922,-0.389 L 28.288,3.032 c 0.135,-0.175 0.203,-0.388 0.203,-0.603"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2098.0076,579.84467)"
+         clip-path="url(#clipPath355)"
+         id="path507" />
+      <path
+         d="M 0,0 2.415,41.381 -34.629,22.784 Z m 4.515,43.05 c 0,-0.019 0,-0.038 -0.003,-0.058 L 1.894,-1.845 c -0.021,-0.356 -0.23,-0.676 -0.549,-0.836 -0.32,-0.16 -0.7,-0.137 -0.998,0.058 l -37.52,24.688 c -0.299,0.195 -0.473,0.547 -0.449,0.895 0.021,0.355 0.23,0.675 0.549,0.835 l 40.139,20.15 c 0.32,0.16 0.701,0.136 0.997,-0.059 0.284,-0.185 0.452,-0.5 0.452,-0.836"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1526.3707,1089.6676)"
+         clip-path="url(#clipPath356)"
+         id="path508" />
+      <path
+         d="M 0,0 2.497,6.083 -4.019,5.204 Z M 5.079,7.305 C 5.079,7.176 5.053,7.047 5.004,6.926 L 1.193,-2.361 C 1.056,-2.693 0.755,-2.925 0.4,-2.972 0.047,-3.021 -0.305,-2.877 -0.524,-2.593 l -6.135,7.945 c -0.222,0.283 -0.265,0.664 -0.135,0.99 0.137,0.332 0.438,0.564 0.793,0.611 L 3.946,8.295 C 4.3,8.344 4.651,8.199 4.87,7.916 5.008,7.738 5.079,7.521 5.079,7.305"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1518.2503,252.498)"
+         clip-path="url(#clipPath357)"
+         id="path509" />
+      <path
+         d="m 0,0 32.106,-8.635 -8.574,32.12 z m 34.518,-10.051 c 0,-0.261 -0.104,-0.517 -0.294,-0.706 -0.253,-0.254 -0.62,-0.352 -0.966,-0.258 L -2.191,-1.48 c -0.345,0.092 -0.615,0.361 -0.707,0.707 -0.087,0.349 0.008,0.713 0.26,0.965 l 25.982,25.931 c 0.254,0.254 0.621,0.351 0.967,0.258 0.346,-0.092 0.615,-0.362 0.707,-0.707 l 9.466,-35.467 c 0.022,-0.086 0.034,-0.172 0.034,-0.258"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2307.6751,43.908)"
+         clip-path="url(#clipPath358)"
+         id="path510" />
+      <path
+         d="M 0,0 34.039,30.052 -9.004,44.505 Z m 36.999,30.448 c 0,-0.283 -0.121,-0.558 -0.338,-0.75 L 0.025,-2.646 c -0.267,-0.236 -0.642,-0.312 -0.98,-0.197 -0.338,0.113 -0.592,0.398 -0.662,0.748 l -9.691,47.901 c -0.074,0.353 0.051,0.712 0.318,0.949 0.268,0.236 0.642,0.312 0.98,0.197 L 36.318,31.395 c 0.338,-0.113 0.591,-0.398 0.661,-0.748 0.014,-0.066 0.02,-0.132 0.02,-0.199"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1416.3675,475.52253)"
+         clip-path="url(#clipPath359)"
+         id="path511" />
+      <path
+         d="M 0,0 7.737,0.914 3.079,7.159 Z m 10.574,0.123 c 0,-0.135 -0.028,-0.267 -0.082,-0.394 -0.141,-0.328 -0.445,-0.557 -0.801,-0.598 L -1.486,-2.187 c -0.355,-0.043 -0.705,0.108 -0.918,0.395 -0.213,0.287 -0.257,0.667 -0.117,0.991 l 4.448,10.34 c 0.141,0.328 0.446,0.556 0.801,0.598 0.355,0.042 0.705,-0.108 0.918,-0.395 l 6.729,-9.021 c 0.131,-0.176 0.199,-0.385 0.199,-0.598"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1573.7165,705.074)"
+         clip-path="url(#clipPath360)"
+         id="path512" />
+      <path
+         d="m 0,0 11.07,47.218 -46.427,-14.02 z m 13.438,48.676 c 0,-0.076 -0.007,-0.152 -0.027,-0.228 L 1.55,-2.142 C 1.47,-2.489 1.208,-2.767 0.867,-2.87 0.525,-2.974 0.154,-2.886 -0.106,-2.642 l -37.881,35.568 c -0.262,0.244 -0.381,0.607 -0.289,0.957 0.08,0.348 0.342,0.625 0.683,0.728 L 12.15,49.633 c 0.341,0.104 0.712,0.016 0.972,-0.228 0.205,-0.192 0.316,-0.455 0.316,-0.729"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2373.0927,1307.8911)"
+         clip-path="url(#clipPath361)"
+         id="path513" />
+      <path
+         d="M 0,0 9.763,2.24 2.945,9.576 Z M 12.675,1.652 C 12.675,1.554 12.661,1.455 12.63,1.359 12.526,1.017 12.247,0.758 11.898,0.677 l -13.14,-3.013 c -0.347,-0.079 -0.711,0.032 -0.955,0.294 -0.244,0.259 -0.336,0.634 -0.222,0.974 l 3.962,12.886 c 0.103,0.341 0.383,0.601 0.732,0.681 0.348,0.08 0.711,-0.031 0.955,-0.293 L 12.408,2.333 C 12.581,2.146 12.675,1.9 12.675,1.652"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1427.5937,256.30453)"
+         clip-path="url(#clipPath362)"
+         id="path514" />
+      <path
+         d="M 0,0 5.169,7.697 -4.085,8.323 Z M 7.963,8.579 C 7.963,8.383 7.906,8.188 7.793,8.022 L 0.695,-2.552 c -0.199,-0.297 -0.541,-0.465 -0.898,-0.441 -0.356,0.025 -0.672,0.236 -0.83,0.556 l -5.61,11.433 c -0.156,0.324 -0.131,0.701 0.068,0.998 0.2,0.297 0.541,0.465 0.899,0.441 L 7.032,9.576 C 7.387,9.551 7.703,9.34 7.861,9.018 7.93,8.879 7.963,8.729 7.963,8.579"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1313.7816,489.9256)"
+         clip-path="url(#clipPath363)"
+         id="path515" />
+      <path
+         d="m 0,0 9.713,5.971 -10.029,5.427 z m 12.71,6.026 c 0,-0.348 -0.18,-0.67 -0.476,-0.852 L -0.427,-2.611 c -0.305,-0.187 -0.686,-0.197 -1,-0.027 -0.315,0.17 -0.514,0.494 -0.524,0.851 l -0.412,14.86 c 0.014,0.379 0.172,0.691 0.477,0.879 0.304,0.187 0.685,0.197 0.999,0.027 L 12.186,6.905 C 12.501,6.735 12.7,6.411 12.71,6.053 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1316.0493,157.81413)"
+         clip-path="url(#clipPath364)"
+         id="path516" />
+      <path
+         d="M 0,0 7.094,4.026 0.059,8.156 Z M 10.094,4.013 V 4.005 C 10.092,3.647 9.898,3.32 9.588,3.144 L -0.517,-2.594 c -0.311,-0.177 -0.691,-0.173 -1,0.007 -0.307,0.179 -0.494,0.507 -0.494,0.863 v 0.008 l 0.082,11.62 c 0.002,0.357 0.195,0.685 0.506,0.861 0.31,0.178 0.691,0.174 0.999,-0.006 L 9.599,4.876 c 0.307,-0.18 0.495,-0.51 0.495,-0.863"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1530.3461,644.3428)"
+         clip-path="url(#clipPath365)"
+         id="path517" />
+      <path
+         d="m 0,0 25.51,-8.08 -5.757,26.135 z m 27.859,-9.556 c 0,-0.277 -0.115,-0.547 -0.326,-0.738 -0.264,-0.24 -0.635,-0.322 -0.977,-0.215 l -28.811,9.126 c -0.34,0.108 -0.598,0.389 -0.674,0.739 -0.076,0.34 0.037,0.71 0.303,0.953 l 22.309,20.389 c 0.264,0.241 0.635,0.323 0.976,0.215 0.34,-0.107 0.598,-0.388 0.674,-0.738 l 6.503,-29.517 c 0.015,-0.07 0.023,-0.142 0.023,-0.214"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1806.4389,442.95973)"
+         clip-path="url(#clipPath366)"
+         id="path518" />
+      <path
+         d="m 0,0 c 0,-0.853 -0.25,-1.781 -0.472,-2.603 -0.25,-0.929 -0.629,-2.327 -0.256,-2.601 0.443,-0.332 0.533,-0.959 0.201,-1.4 -0.332,-0.441 -0.959,-0.531 -1.4,-0.201 -1.457,1.09 -0.938,3.017 -0.476,4.721 0.25,0.928 0.628,2.32 0.255,2.603 -0.373,0.28 -1.609,-0.474 -2.425,-0.974 -1.431,-0.875 -3.212,-1.962 -4.671,-0.871 -1.458,1.092 -0.912,3.105 -0.478,4.724 0.252,0.925 0.628,2.325 0.254,2.605 -0.373,0.279 -1.609,-0.477 -2.428,-0.975 -1.431,-0.875 -3.212,-1.962 -4.668,-0.871 -1.459,1.096 -0.918,3.109 -0.483,4.728 0.248,0.927 0.625,2.323 0.25,2.606 -0.375,0.281 -1.613,-0.472 -2.433,-0.972 -1.431,-0.873 -3.212,-1.959 -4.671,-0.867 -0.441,0.336 -0.529,0.963 -0.201,1.4 0.332,0.441 0.957,0.531 1.4,0.201 0.375,-0.281 1.613,0.475 2.431,0.973 1.432,0.873 3.214,1.96 4.673,0.867 1.459,-1.094 0.916,-3.105 0.483,-4.726 -0.25,-0.931 -0.619,-2.335 -0.25,-2.609 0.372,-0.279 1.609,0.477 2.427,0.975 1.431,0.874 3.212,1.962 4.669,0.871 C -6.811,6.51 -7.352,4.495 -7.791,2.878 -8.039,1.953 -8.42,0.557 -8.045,0.275 c 0.373,-0.279 1.611,0.477 2.429,0.977 1.43,0.872 3.211,1.96 4.667,0.869 C -0.232,1.584 0,0.826 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2427.0695,1050.0101)"
+         clip-path="url(#clipPath367)"
+         id="path519" />
+      <path
+         d="M 0,0 C 0,-0.336 -0.172,-0.666 -0.48,-0.855 -0.953,-1.14 -1.568,-0.99 -1.855,-0.519 -3.573,2.31 -8.619,1.468 -13.5,0.654 c -5.538,-0.924 -11.263,-1.88 -13.685,2.107 -2.419,4.001 1.07,8.627 4.444,13.112 2.974,3.957 6.052,8.053 4.331,10.875 -1.714,2.823 -6.758,1.98 -11.637,1.162 -5.536,-0.928 -11.26,-1.887 -13.677,2.095 -2.421,3.985 1.078,8.623 4.452,13.104 2.976,3.949 6.059,8.036 4.339,10.857 -1.713,2.824 -6.758,1.978 -11.636,1.16 -5.536,-0.928 -11.259,-1.886 -13.677,2.093 -2.407,3.98 1.078,8.611 4.458,13.093 2.978,3.95 6.059,8.039 4.343,10.851 -0.289,0.473 -0.133,1.088 0.336,1.375 0.472,0.285 1.087,0.135 1.375,-0.336 2.411,-3.98 -1.078,-8.613 -4.458,-13.093 -2.978,-3.95 -6.062,-8.033 -4.343,-10.851 1.712,-2.824 6.758,-1.978 11.636,-1.16 5.536,0.928 11.259,1.887 13.676,-2.093 2.418,-3.98 -1.074,-8.613 -4.452,-13.101 -2.976,-3.95 -6.057,-8.041 -4.339,-10.86 1.713,-2.824 6.759,-1.978 11.637,-1.162 5.535,0.927 11.261,1.886 13.678,-2.095 2.421,-3.999 -1.07,-8.629 -4.445,-13.114 C -24.119,10.718 -27.193,6.624 -25.474,3.8 -23.758,0.971 -18.71,1.812 -13.831,2.626 -8.293,3.55 -2.566,4.507 -0.144,0.519 -0.047,0.358 0,0.178 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1891.9035,1152.7885)"
+         clip-path="url(#clipPath368)"
+         id="path520" />
+      <path
+         d="m 0,0 c 0,-0.106 -0.016,-0.211 -0.051,-0.316 -0.176,-0.524 -0.742,-0.807 -1.265,-0.633 -3.341,1.117 -6.837,-3.011 -10.217,-7.002 -3.81,-4.501 -7.75,-9.155 -12.376,-7.61 -4.628,1.547 -4.981,7.633 -5.323,13.518 -0.302,5.222 -0.617,10.623 -3.958,11.738 -3.335,1.115 -6.826,-3.013 -10.204,-7.006 -3.806,-4.503 -7.745,-9.156 -12.365,-7.616 -4.62,1.545 -4.97,7.63 -5.307,13.517 -0.299,5.219 -0.609,10.616 -3.943,11.729 -3.335,1.114 -6.824,-3.015 -10.203,-7.008 -3.805,-4.501 -7.742,-9.156 -12.36,-7.613 -4.614,1.54 -4.962,7.627 -5.298,13.51 -0.296,5.22 -0.603,10.617 -3.932,11.728 -0.525,0.178 -0.807,0.744 -0.633,1.265 0.176,0.524 0.742,0.807 1.265,0.633 4.615,-1.54 4.962,-7.627 5.298,-13.51 0.297,-5.22 0.604,-10.617 3.933,-11.728 3.335,-1.113 6.825,3.015 10.203,7.008 3.805,4.501 7.742,9.156 12.36,7.613 4.62,-1.542 4.97,-7.629 5.307,-13.514 0.299,-5.219 0.61,-10.619 3.943,-11.732 3.337,-1.115 6.828,3.015 10.204,7.008 3.808,4.501 7.745,9.156 12.365,7.614 4.628,-1.546 4.981,-7.633 5.323,-13.519 0.303,-5.221 0.617,-10.622 3.958,-11.737 3.343,-1.117 6.838,3.011 10.218,7.004 3.81,4.499 7.748,9.152 12.375,7.608 C -0.264,0.808 0,0.418 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1590.7259,357.1432)"
+         clip-path="url(#clipPath369)"
+         id="path521" />
+      <path
+         d="m 0,0 c 0,-0.486 -0.358,-0.914 -0.853,-0.988 -1.594,-0.235 -2.24,-2.943 -2.865,-5.563 -0.779,-3.267 -1.586,-6.647 -4.515,-7.079 -2.932,-0.431 -4.676,2.574 -6.365,5.479 -1.354,2.33 -2.754,4.738 -4.345,4.503 -1.585,-0.232 -2.23,-2.942 -2.853,-5.561 -0.777,-3.269 -1.581,-6.647 -4.51,-7.078 -2.928,-0.432 -4.671,2.573 -6.356,5.479 -1.352,2.33 -2.748,4.737 -4.333,4.503 -1.588,-0.233 -2.232,-2.941 -2.855,-5.561 -0.777,-3.267 -1.582,-6.647 -4.509,-7.077 -2.923,-0.429 -4.665,2.576 -6.348,5.481 -1.351,2.328 -2.747,4.737 -4.329,4.503 -0.547,-0.08 -1.055,0.299 -1.137,0.844 -0.07,0.548 0.297,1.056 0.844,1.136 2.925,0.43 4.667,-2.576 6.35,-5.481 1.351,-2.33 2.747,-4.737 4.329,-4.503 1.587,0.232 2.232,2.941 2.855,5.559 0.777,3.269 1.581,6.647 4.507,7.079 2.927,0.43 4.67,-2.574 6.356,-5.48 1.351,-2.329 2.747,-4.736 4.334,-4.502 1.588,0.232 2.232,2.94 2.855,5.561 0.779,3.267 1.582,6.645 4.509,7.078 2.933,0.43 4.677,-2.573 6.366,-5.479 1.353,-2.329 2.751,-4.737 4.343,-4.503 1.591,0.233 2.237,2.943 2.862,5.561 0.779,3.269 1.586,6.649 4.517,7.081 0.547,0.08 1.054,-0.299 1.136,-0.844 C -0.004,0.098 0,0.049 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1589.2079,1146.8524)"
+         clip-path="url(#clipPath370)"
+         id="path522" />
+      <path
+         d="m 0,0 c 0,-2.695 -2.929,-4.351 -5.768,-5.956 -2.435,-1.38 -4.958,-2.757 -4.736,-4.473 0.092,-0.555 -0.306,-1.053 -0.855,-1.125 -0.547,-0.074 -1.051,0.309 -1.125,0.855 -0.415,3.021 2.711,4.776 5.732,6.483 2.436,1.381 4.973,2.802 4.735,4.474 -0.229,1.669 -3.041,2.37 -5.759,3.048 -3.366,0.839 -6.848,1.706 -7.256,4.719 -0.439,3.021 2.712,4.78 5.729,6.489 2.441,1.381 4.95,2.841 4.736,4.48 -0.229,1.671 -3.041,2.372 -5.761,3.05 -3.366,0.839 -6.846,1.708 -7.256,4.721 -0.404,3.025 2.712,4.788 5.729,6.497 2.441,1.382 4.942,2.808 4.733,4.487 -0.228,1.675 -3.04,2.38 -5.76,3.06 -3.366,0.841 -6.846,1.71 -7.256,4.729 -0.104,0.539 0.307,1.051 0.855,1.125 0.547,0.074 1.051,-0.309 1.125,-0.855 0.229,-1.676 3.04,-2.38 5.76,-3.06 3.367,-0.842 6.846,-1.711 7.256,-4.73 0.41,-3.03 -2.71,-4.786 -5.727,-6.494 -2.441,-1.383 -4.989,-2.861 -4.735,-4.489 0.228,-1.672 3.04,-2.373 5.76,-3.051 3.367,-0.839 6.846,-1.708 7.257,-4.721 0.414,-3.001 -2.711,-4.78 -5.73,-6.489 -2.443,-1.38 -4.938,-2.808 -4.735,-4.479 0.229,-1.67 3.04,-2.371 5.758,-3.048 3.367,-0.84 6.848,-1.707 7.257,-4.72 C -0.012,0.347 0,0.172 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1974.95,326.57213)"
+         clip-path="url(#clipPath371)"
+         id="path523" />
+      <path
+         d="m 0,0 c 0,-1.076 -0.297,-2.092 -1.015,-3.015 -2.455,-3.15 -7.149,-1.793 -11.689,-0.48 -3.9,1.126 -7.934,2.292 -9.554,0.209 -1.621,-2.078 0.503,-5.702 2.55,-9.204 2.386,-4.076 4.846,-8.294 2.404,-11.442 -2.451,-3.146 -7.144,-1.787 -11.681,-0.473 -3.898,1.131 -7.93,2.299 -9.547,0.221 -1.621,-2.086 0.5,-5.702 2.552,-9.201 2.388,-4.081 4.854,-8.295 2.406,-11.443 -2.449,-3.143 -7.141,-1.78 -11.677,-0.464 -3.898,1.132 -7.926,2.3 -9.541,0.226 -0.34,-0.435 -0.967,-0.513 -1.404,-0.174 -0.435,0.338 -0.515,0.965 -0.174,1.404 2.447,3.142 7.139,1.781 11.675,0.465 3.898,-1.132 7.928,-2.302 9.543,-0.227 1.617,2.074 -0.504,5.7 -2.554,9.202 -2.388,4.079 -4.855,8.287 -2.404,11.44 2.451,3.146 7.143,1.787 11.681,0.473 3.898,-1.131 7.93,-2.298 9.547,-0.221 1.611,2.078 -0.502,5.698 -2.551,9.205 -2.39,4.077 -4.856,8.291 -2.403,11.443 2.454,3.149 7.149,1.792 11.688,0.48 3.9,-1.127 7.934,-2.292 9.555,-0.209 1.626,2.082 -0.498,5.71 -2.545,9.211 -2.385,4.081 -4.844,8.301 -2.395,11.452 0.34,0.436 0.968,0.514 1.404,0.174 0.433,-0.341 0.511,-0.968 0.173,-1.404 -1.618,-2.072 0.497,-5.704 2.545,-9.212 C -1.726,5.552 0,2.597 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1597.6693,797.10987)"
+         clip-path="url(#clipPath372)"
+         id="path524" />
+      <path
+         d="m 0,0 c 0,-0.263 -0.104,-0.527 -0.309,-0.723 -3.507,-3.348 -9.031,-0.823 -14.371,1.621 -4.736,2.166 -9.633,4.406 -12.16,1.992 -2.53,-2.417 -0.519,-7.411 1.428,-12.243 2.195,-5.45 4.464,-11.083 0.956,-14.436 -3.51,-3.353 -9.035,-0.83 -14.379,1.613 -4.737,2.163 -9.637,4.403 -12.165,1.985 -2.533,-2.417 -0.523,-7.416 1.425,-12.245 2.197,-5.454 4.462,-11.087 0.953,-14.44 -3.516,-3.358 -9.045,-0.837 -14.389,1.601 -4.741,2.162 -9.642,4.398 -12.177,1.977 -2.539,-2.43 -0.529,-7.423 1.416,-12.26 2.192,-5.446 4.456,-11.089 0.943,-14.445 -0.401,-0.383 -1.033,-0.368 -1.414,0.031 -0.383,0.398 -0.367,1.035 0.031,1.414 2.537,2.419 0.526,7.422 -1.415,12.257 -2.191,5.452 -4.46,11.087 -0.943,14.447 3.514,3.359 9.042,0.836 14.389,-1.601 4.739,-2.163 9.64,-4.399 12.176,-1.976 2.533,2.418 0.522,7.415 -1.425,12.247 -2.191,5.448 -4.466,11.08 -0.953,14.438 3.511,3.353 9.035,0.828 14.38,-1.613 4.737,-2.163 9.636,-4.403 12.165,-1.985 2.529,2.417 0.517,7.412 -1.427,12.243 -2.195,5.452 -4.464,11.085 -0.957,14.436 3.507,3.351 9.031,0.824 14.374,-1.619 4.734,-2.165 9.63,-4.405 12.157,-1.993 0.4,0.382 1.033,0.367 1.413,-0.032 C -0.092,0.496 0,0.248 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2285.5895,107.85187)"
+         clip-path="url(#clipPath373)"
+         id="path525" />
+      <path
+         d="m 0,0 c 0,-0.172 -0.043,-0.346 -0.137,-0.503 -0.277,-0.477 -0.89,-0.639 -1.367,-0.36 -3.409,1.988 -8.131,-1.699 -12.694,-5.262 -5.089,-3.974 -10.351,-8.083 -14.932,-5.413 -4.579,2.669 -3.601,9.271 -2.652,15.658 0.85,5.733 1.732,11.652 -1.681,13.64 -3.404,1.982 -8.12,-1.705 -12.681,-5.27 -5.085,-3.976 -10.345,-8.087 -14.918,-5.421 -4.575,2.663 -3.589,9.265 -2.638,15.653 0.857,5.727 1.735,11.645 -1.666,13.627 -3.401,1.982 -8.117,-1.705 -12.678,-5.272 -5.085,-3.976 -10.344,-8.086 -14.917,-5.423 -4.567,2.66 -3.581,9.258 -2.627,15.647 0.856,5.725 1.744,11.646 -1.655,13.624 -0.479,0.279 -0.645,0.889 -0.36,1.367 0.278,0.476 0.889,0.638 1.367,0.359 4.567,-2.657 3.581,-9.258 2.627,-15.646 -0.854,-5.722 -1.74,-11.643 1.655,-13.625 3.402,-1.979 8.118,1.707 12.677,5.273 5.087,3.975 10.346,8.088 14.919,5.422 4.569,-2.663 3.585,-9.267 2.636,-15.649 -0.85,-5.723 -1.734,-11.647 1.667,-13.631 3.402,-1.982 8.12,1.705 12.679,5.27 5.087,3.976 10.345,8.088 14.921,5.421 4.581,-2.669 3.6,-9.272 2.651,-15.658 -0.847,-5.728 -1.728,-11.648 1.682,-13.64 3.409,-1.986 8.129,1.699 12.694,5.262 5.088,3.974 10.351,8.084 14.932,5.413 C -0.178,0.678 0,0.344 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1911.514,330.272)"
+         clip-path="url(#clipPath374)"
+         id="path526" />
+      <path
+         d="m 0,0 c 0,-0.519 -0.402,-0.959 -0.929,-0.996 -4.948,-0.348 -7.655,5.263 -10.27,10.685 -2.325,4.825 -4.731,9.812 -8.328,9.559 -3.602,-0.252 -5.288,-5.529 -6.918,-10.629 -1.834,-5.737 -3.73,-11.667 -8.684,-12.017 -4.953,-0.348 -7.662,5.261 -10.281,10.683 -2.327,4.825 -4.735,9.813 -8.337,9.559 -3.605,-0.252 -5.292,-5.528 -6.925,-10.631 -1.835,-5.735 -3.731,-11.665 -8.685,-12.014 -4.962,-0.35 -7.674,5.258 -10.297,10.683 -2.333,4.823 -4.745,9.81 -8.353,9.556 -3.611,-0.254 -5.301,-5.53 -6.938,-10.632 -1.84,-5.736 -3.739,-11.668 -8.701,-12.017 -0.551,-0.039 -1.029,0.377 -1.068,0.927 -0.049,0.512 0.375,1.029 0.928,1.069 3.61,0.253 5.301,5.53 6.937,10.632 1.84,5.735 3.74,11.667 8.701,12.016 4.96,0.348 7.673,-5.258 10.295,-10.681 2.331,-4.825 4.745,-9.812 8.355,-9.558 3.603,0.252 5.29,5.528 6.922,10.628 1.836,5.738 3.732,11.668 8.688,12.017 4.954,0.348 7.662,-5.26 10.281,-10.683 2.327,-4.825 4.735,-9.812 8.338,-9.558 3.601,0.252 5.288,5.528 6.918,10.63 1.834,5.735 3.73,11.668 8.684,12.015 4.948,0.348 7.654,-5.261 10.269,-10.685 C -7.071,5.735 -4.667,0.748 -1.07,1 -0.519,1.039 -0.041,0.623 -0.002,0.072 0,0.049 0,0.025 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1975.5824,116.2168)"
+         clip-path="url(#clipPath375)"
+         id="path527" />
+      <path
+         d="m 0,0 c 0,-0.381 -0.219,-0.746 -0.59,-0.912 -3.27,-1.468 -6.385,1.55 -9.396,4.47 -2.533,2.454 -5.153,4.993 -7.186,4.081 -2.038,-0.916 -1.884,-4.564 -1.734,-8.084 0.178,-4.197 0.359,-8.526 -2.913,-9.994 -3.275,-1.469 -6.391,1.548 -9.404,4.468 -2.533,2.454 -5.153,4.991 -7.19,4.077 -2.04,-0.916 -1.882,-4.564 -1.738,-8.084 0.182,-4.193 0.355,-8.526 -2.915,-9.994 -3.279,-1.472 -6.397,1.545 -9.414,4.462 -2.537,2.454 -5.159,4.991 -7.199,4.075 -2.045,-0.92 -1.895,-4.563 -1.746,-8.09 0.176,-4.194 0.351,-8.529 -2.925,-9.998 -0.504,-0.226 -1.096,-0.001 -1.322,0.502 -0.231,0.496 -0.004,1.094 0.501,1.322 2.047,0.918 1.898,4.564 1.746,8.09 -0.17,4.199 -0.351,8.528 2.925,9.998 3.279,1.47 6.395,-1.545 9.41,-4.462 2.537,-2.454 5.161,-4.991 7.204,-4.075 2.04,0.914 1.886,4.557 1.737,8.086 -0.175,4.186 -0.359,8.521 2.918,9.992 3.27,1.47 6.387,-1.547 9.4,-4.466 2.534,-2.455 5.155,-4.993 7.192,-4.079 2.038,0.918 1.884,4.567 1.735,8.086 -0.183,4.188 -0.361,8.521 2.912,9.992 3.273,1.468 6.387,-1.551 9.398,-4.47 C -6.061,2.538 -3.442,0 -1.41,0.912 -0.906,1.138 -0.314,0.914 -0.088,0.41 -0.027,0.277 0,0.136 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1385.0541,221.9268)"
+         clip-path="url(#clipPath376)"
+         id="path528" />
+      <path
+         d="m 0,0 c 0,-0.223 -0.035,-0.455 -0.112,-0.695 -0.546,-1.734 -2.622,-1.888 -4.291,-2.013 -0.953,-0.071 -2.393,-0.178 -2.533,-0.621 -0.117,-0.434 0.974,-1.353 1.716,-1.959 1.293,-1.058 2.9,-2.386 2.357,-4.11 -0.547,-1.734 -2.622,-1.887 -4.29,-2.01 -0.953,-0.068 -2.392,-0.175 -2.532,-0.615 -0.124,-0.433 0.978,-1.353 1.718,-1.96 1.293,-1.059 2.913,-2.384 2.357,-4.108 -0.549,-1.733 -2.623,-1.885 -4.29,-2.008 -0.953,-0.068 -2.392,-0.174 -2.531,-0.613 -0.166,-0.528 -0.726,-0.818 -1.253,-0.652 -0.524,0.166 -0.819,0.732 -0.653,1.253 0.547,1.732 2.623,1.885 4.29,2.008 0.953,0.068 2.392,0.174 2.531,0.615 0.135,0.406 -0.978,1.353 -1.718,1.959 -1.293,1.056 -2.914,2.376 -2.357,4.108 0.546,1.734 2.622,1.886 4.29,2.009 0.952,0.069 2.392,0.176 2.532,0.615 0.127,0.453 -0.976,1.357 -1.718,1.963 -1.294,1.058 -2.904,2.393 -2.355,4.108 0.549,1.734 2.625,1.888 4.29,2.013 0.953,0.07 2.394,0.178 2.535,0.621 0.115,0.408 -0.977,1.357 -1.717,1.964 -1.292,1.063 -2.898,2.393 -2.355,4.113 0.166,0.527 0.727,0.818 1.254,0.652 0.527,-0.164 0.816,-0.726 0.652,-1.253 -0.132,-0.44 0.975,-1.36 1.717,-1.965 C -1.351,2.505 0,1.4 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2028.6487,534.324)"
+         clip-path="url(#clipPath377)"
+         id="path529" />
+      <path
+         d="m 0,0 c 0,-0.34 -0.173,-0.671 -0.488,-0.859 -4.762,-2.839 -10.34,1.437 -15.735,5.573 -4.864,3.73 -9.894,7.586 -13.493,5.442 -3.604,-2.148 -2.608,-8.41 -1.642,-14.463 1.068,-6.712 2.176,-13.656 -2.593,-16.497 -4.766,-2.841 -10.347,1.434 -15.744,5.567 -4.868,3.728 -9.9,7.585 -13.505,5.435 -3.603,-2.148 -2.607,-8.409 -1.646,-14.466 1.066,-6.713 2.169,-13.657 -2.597,-16.498 -4.774,-2.845 -10.359,1.425 -15.758,5.557 -4.872,3.726 -9.91,7.581 -13.523,5.427 -3.612,-2.152 -2.622,-8.416 -1.657,-14.473 1.058,-6.719 2.163,-13.663 -2.611,-16.506 -0.475,-0.283 -1.088,-0.127 -1.371,0.347 -0.283,0.469 -0.131,1.086 0.348,1.371 3.61,2.152 2.618,8.418 1.657,14.473 -1.064,6.716 -2.167,13.66 2.611,16.506 4.776,2.845 10.361,-1.425 15.76,-5.557 4.872,-3.726 9.908,-7.58 13.52,-5.426 3.605,2.149 2.611,8.412 1.647,14.467 -1.068,6.709 -2.172,13.655 2.597,16.496 4.766,2.841 10.347,-1.433 15.744,-5.567 4.868,-3.728 9.9,-7.584 13.505,-5.434 3.6,2.144 2.607,8.404 1.642,14.463 -1.068,6.71 -2.175,13.657 2.593,16.496 4.763,2.839 10.34,-1.437 15.735,-5.573 C -10.14,2.572 -5.11,-1.285 -1.511,0.859 -1.036,1.143 -0.423,0.986 -0.14,0.512 -0.045,0.352 0,0.176 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2079.3265,866.81813)"
+         clip-path="url(#clipPath378)"
+         id="path530" />
+      <path
+         d="m 0,0 c 0,-2.138 -0.576,-3.977 -2.263,-5.218 -3.55,-2.607 -8.178,0.274 -12.654,3.06 -3.909,2.435 -7.953,4.954 -10.413,3.146 -2.454,-1.8 -1.257,-6.409 -0.102,-10.868 1.322,-5.105 2.689,-10.379 -0.855,-12.984 -3.546,-2.605 -8.17,0.279 -12.642,3.07 -3.907,2.437 -7.947,4.955 -10.401,3.153 -2.455,-1.802 -1.258,-6.412 -0.1,-10.868 1.32,-5.103 2.695,-10.375 -0.851,-12.982 -3.543,-2.601 -8.164,0.285 -12.636,3.076 -3.906,2.439 -7.943,4.96 -10.394,3.159 -0.446,-0.326 -1.07,-0.23 -1.398,0.215 -0.324,0.439 -0.234,1.068 0.215,1.398 3.542,2.601 8.166,-0.285 12.637,-3.076 3.904,-2.436 7.942,-4.957 10.393,-3.159 2.45,1.801 1.253,6.409 0.099,10.867 -1.326,5.102 -2.695,10.376 0.851,12.983 3.546,2.603 8.17,-0.281 12.644,-3.069 3.907,-2.437 7.945,-4.956 10.4,-3.154 2.454,1.8 1.255,6.411 0.102,10.869 -1.325,5.104 -2.689,10.376 0.855,12.983 3.552,2.607 8.179,-0.273 12.655,-3.062 3.909,-2.433 7.951,-4.952 10.412,-3.144 2.458,1.805 1.265,6.415 0.111,10.877 -1.32,5.102 -2.689,10.378 0.865,12.989 0.445,0.326 1.07,0.23 1.398,-0.215 C -0.748,19.605 -0.84,18.98 -1.287,18.648 -3.749,16.84 -2.554,12.232 -1.398,7.771 -0.705,5.092 0,2.365 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2317.2589,200.40333)"
+         clip-path="url(#clipPath379)"
+         id="path531" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.582 -0.367,-0.783 -1.162,-0.971 -2.593,-0.197 -3.741,0.426 -0.45,0.242 -1.283,0.693 -1.537,0.636 -0.043,-0.207 0.234,-1.103 0.396,-1.589 0.405,-1.244 0.908,-2.787 -0.248,-3.761 -1.164,-0.97 -2.595,-0.197 -3.745,0.426 -0.449,0.242 -1.283,0.693 -1.537,0.636 -0.074,-0.212 0.235,-1.105 0.395,-1.591 0.404,-1.244 0.915,-2.79 -0.25,-3.761 -1.162,-0.971 -2.595,-0.199 -3.746,0.422 -0.449,0.242 -1.284,0.693 -1.538,0.634 -0.074,-0.197 0.232,-1.109 0.39,-1.593 0.405,-1.244 0.912,-2.792 -0.252,-3.761 -0.423,-0.353 -1.054,-0.297 -1.408,0.127 -0.353,0.422 -0.298,1.052 0.127,1.408 0.082,0.228 -0.209,1.121 -0.367,1.605 -0.406,1.24 -0.913,2.788 0.252,3.761 1.162,0.972 2.595,0.199 3.745,-0.422 0.452,-0.242 1.287,-0.693 1.539,-0.635 0.049,0.198 -0.234,1.11 -0.392,1.592 -0.406,1.24 -0.918,2.788 0.25,3.761 1.161,0.97 2.593,0.197 3.743,-0.426 0.449,-0.242 1.283,-0.693 1.536,-0.636 0.067,0.218 -0.237,1.109 -0.396,1.591 -0.408,1.242 -0.91,2.79 0.25,3.759 1.162,0.97 2.593,0.197 3.742,-0.426 0.449,-0.242 1.283,-0.693 1.536,-0.637 0.424,0.356 1.041,0.292 1.395,-0.132 C -0.074,0.447 0,0.225 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1991.8028,791.5176)"
+         clip-path="url(#clipPath380)"
+         id="path532" />
+      <path
+         d="m 0,0 c 0,-0.062 -0.006,-0.123 -0.018,-0.186 -0.101,-0.542 -0.622,-0.9 -1.165,-0.798 -2.134,0.398 -2.619,2.855 -3.046,5.022 -0.303,1.543 -0.649,3.29 -1.449,3.441 -0.803,0.15 -1.757,-1.357 -2.599,-2.687 -1.182,-1.865 -2.519,-3.98 -4.655,-3.581 -2.136,0.398 -2.621,2.852 -3.049,5.02 -0.304,1.542 -0.65,3.292 -1.452,3.442 -0.805,0.151 -1.758,-1.357 -2.599,-2.686 -1.182,-1.865 -2.521,-3.98 -4.657,-3.581 -2.139,0.398 -2.625,2.854 -3.055,5.022 -0.304,1.543 -0.651,3.292 -1.458,3.444 -0.807,0.15 -1.761,-1.357 -2.603,-2.687 -1.183,-1.864 -2.523,-3.979 -4.661,-3.579 -0.545,0.102 -0.898,0.629 -0.799,1.166 0.102,0.543 0.623,0.9 1.166,0.799 0.806,-0.151 1.761,1.357 2.605,2.684 1.181,1.867 2.521,3.98 4.659,3.582 2.138,-0.399 2.624,-2.855 3.054,-5.023 0.305,-1.542 0.652,-3.292 1.459,-3.444 0.804,-0.15 1.757,1.357 2.599,2.687 1.181,1.864 2.521,3.98 4.657,3.581 2.136,-0.399 2.62,-2.853 3.048,-5.02 0.304,-1.543 0.65,-3.293 1.453,-3.443 0.802,-0.15 1.757,1.357 2.599,2.687 1.181,1.865 2.519,3.979 4.655,3.581 C -3.177,9.045 -2.695,6.59 -2.267,4.425 -1.962,2.88 -1.618,1.131 -0.816,0.98 -0.335,0.89 0,0.471 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2569.8596,453.87893)"
+         clip-path="url(#clipPath381)"
+         id="path533" />
+      <path
+         d="m 0,0 c 0,-0.051 -0.004,-0.1 -0.012,-0.15 -0.08,-0.545 -0.589,-0.922 -1.136,-0.84 -0.246,0.035 -0.912,-1.103 -1.164,-1.531 -0.713,-1.221 -1.601,-2.736 -3.185,-2.497 -1.583,0.238 -1.988,1.948 -2.31,3.323 -0.115,0.482 -0.416,1.767 -0.662,1.804 -0.244,0.037 -0.933,-1.142 -1.16,-1.531 -0.712,-1.218 -1.599,-2.735 -3.182,-2.497 -1.584,0.236 -1.984,1.949 -2.309,3.323 -0.101,0.438 -0.414,1.768 -0.656,1.804 -0.244,0.036 -0.933,-1.144 -1.16,-1.53 -0.712,-1.22 -1.599,-2.738 -3.183,-2.5 -1.581,0.239 -1.984,1.949 -2.305,3.324 -0.102,0.437 -0.412,1.767 -0.655,1.804 -0.548,0.082 -0.923,0.613 -0.839,1.136 0.082,0.547 0.591,0.922 1.136,0.84 1.582,-0.238 1.984,-1.949 2.306,-3.323 0.102,-0.438 0.412,-1.768 0.655,-1.804 0.243,-0.036 0.933,1.144 1.159,1.53 0.713,1.221 1.6,2.738 3.183,2.5 1.584,-0.239 1.984,-1.949 2.306,-3.324 0.104,-0.437 0.416,-1.767 0.658,-1.804 0.244,-0.037 0.934,1.142 1.16,1.531 0.713,1.219 1.599,2.736 3.183,2.498 1.583,-0.239 1.988,-1.949 2.31,-3.324 0.115,-0.482 0.416,-1.767 0.662,-1.804 0.246,-0.037 0.912,1.103 1.164,1.531 0.712,1.218 1.601,2.735 3.185,2.497 C -0.355,0.912 0,0.486 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2476.7561,497.6476)"
+         clip-path="url(#clipPath382)"
+         id="path534" />
+      <path
+         d="m 0,0 c 0,-2.371 -2.125,-4.702 -4.192,-6.973 -2.123,-2.328 -4.308,-4.726 -3.466,-6.485 0.25,-0.494 0.035,-1.095 -0.461,-1.336 -0.496,-0.242 -1.096,-0.035 -1.336,0.461 -1.447,2.972 1.213,5.886 3.784,8.707 2.121,2.328 4.31,4.733 3.466,6.487 -0.853,1.754 -4.102,1.515 -7.246,1.285 -3.805,-0.279 -7.744,-0.566 -9.187,2.404 -1.447,2.966 1.208,5.887 3.78,8.713 2.123,2.331 4.312,4.744 3.464,6.492 -0.853,1.754 -4.104,1.515 -7.246,1.287 -3.808,-0.279 -7.745,-0.566 -9.19,2.405 -1.442,2.973 1.211,5.9 3.777,8.721 2.121,2.334 4.302,4.745 3.46,6.503 -0.855,1.757 -4.106,1.523 -7.25,1.294 -3.81,-0.277 -7.746,-0.562 -9.193,2.414 -0.237,0.492 -0.037,1.095 0.46,1.335 0.496,0.243 1.096,0.036 1.336,-0.46 0.856,-1.758 4.106,-1.524 7.25,-1.295 3.81,0.277 7.747,0.562 9.194,-2.414 1.454,-2.969 -1.205,-5.893 -3.777,-8.722 -2.12,-2.332 -4.317,-4.747 -3.458,-6.501 0.851,-1.753 4.103,-1.515 7.244,-1.286 3.808,0.279 7.745,0.566 9.19,-2.406 1.446,-2.98 -1.213,-5.893 -3.781,-8.713 -2.12,-2.332 -4.309,-4.729 -3.464,-6.493 0.853,-1.753 4.103,-1.515 7.247,-1.285 3.805,0.28 7.744,0.567 9.187,-2.403 C -0.125,1.156 0,0.576 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2485.978,1000.4119)"
+         clip-path="url(#clipPath383)"
+         id="path535" />
+      <path
+         d="m 0,0 c 0,-0.967 -0.219,-1.925 -0.709,-2.869 -2.451,-4.719 -9.117,-4.057 -15.565,-3.419 -5.787,0.573 -11.77,1.166 -13.598,-2.352 -1.83,-3.529 2.103,-8.065 5.901,-12.461 4.233,-4.905 8.613,-9.978 6.162,-14.69 -2.446,-4.713 -9.113,-4.047 -15.561,-3.405 -5.783,0.578 -11.762,1.174 -13.586,-2.336 -1.814,-3.497 2.107,-8.054 5.905,-12.458 4.233,-4.903 8.615,-9.976 6.162,-14.686 -2.444,-4.707 -9.109,-4.04 -15.555,-3.393 -5.781,0.579 -11.76,1.177 -13.581,-2.326 -0.253,-0.49 -0.857,-0.681 -1.347,-0.426 -0.492,0.256 -0.685,0.865 -0.426,1.348 2.445,4.708 9.11,4.04 15.556,3.394 5.781,-0.58 11.76,-1.178 13.58,2.325 1.822,3.515 -2.109,8.061 -5.903,12.458 -4.237,4.905 -8.615,9.978 -6.164,14.686 2.446,4.712 9.113,4.046 15.559,3.404 5.784,-0.576 11.764,-1.174 13.588,2.337 1.816,3.507 -2.103,8.063 -5.903,12.462 -4.231,4.903 -8.615,9.967 -6.16,14.688 2.451,4.72 9.119,4.06 15.568,3.421 5.784,-0.574 11.767,-1.166 13.595,2.351 1.824,3.525 -2.099,8.07 -5.895,12.474 -4.232,4.911 -8.598,9.992 -6.155,14.704 0.254,0.49 0.857,0.681 1.347,0.425 0.492,-0.253 0.686,-0.861 0.426,-1.347 -1.822,-3.513 2.095,-8.071 5.897,-12.476 C -3.478,7.907 -0.002,3.872 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1793.6557,-42.782933)"
+         clip-path="url(#clipPath384)"
+         id="path536" />
+      <path
+         d="m 0,0 c 0,-0.248 -0.092,-0.496 -0.276,-0.689 -0.38,-0.4 -1.013,-0.416 -1.413,-0.035 -0.238,0.08 -1.146,-0.336 -1.633,-0.559 -1.216,-0.556 -2.73,-1.25 -3.844,-0.187 -1.113,1.066 -0.496,2.609 0,3.849 0.199,0.498 0.57,1.425 0.47,1.669 -0.232,0.068 -1.136,-0.348 -1.625,-0.57 -1.214,-0.559 -2.725,-1.252 -3.84,-0.192 -1.112,1.065 -0.493,2.607 0.002,3.849 0.199,0.498 0.562,1.416 0.472,1.67 -0.23,0.064 -1.136,-0.352 -1.622,-0.574 -1.215,-0.557 -2.729,-1.252 -3.843,-0.192 -1.111,1.06 -0.494,2.609 0.003,3.847 0.202,0.498 0.573,1.418 0.473,1.668 -0.398,0.384 -0.408,1.011 -0.029,1.408 0.381,0.398 1.019,0.408 1.417,0.027 1.115,-1.059 0.496,-2.605 -0.003,-3.847 -0.199,-0.496 -0.582,-1.423 -0.473,-1.667 0.228,-0.065 1.134,0.351 1.621,0.573 1.214,0.557 2.728,1.252 3.842,0.192 1.115,-1.059 0.496,-2.605 -10e-4,-3.849 -0.202,-0.496 -0.553,-1.421 -0.473,-1.669 0.231,-0.065 1.136,0.349 1.623,0.574 1.214,0.556 2.727,1.252 3.843,0.189 1.117,-1.06 0.498,-2.606 0,-3.849 -0.2,-0.499 -0.578,-1.431 -0.471,-1.669 0.232,-0.07 1.138,0.346 1.626,0.568 1.215,0.557 2.728,1.25 3.844,0.19 C -0.104,0.527 0,0.264 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2401.0655,332.76373)"
+         clip-path="url(#clipPath385)"
+         id="path537" />
+      <path
+         d="m 0,0 c 0,-0.226 -0.076,-0.453 -0.23,-0.638 -3.292,-3.959 -9.457,-1.949 -15.418,-0.008 -5.327,1.736 -10.836,3.53 -13.261,0.615 -2.427,-2.912 0.334,-8.01 3.005,-12.936 2.99,-5.513 6.079,-11.207 2.787,-15.173 -3.299,-3.96 -9.463,-1.953 -15.426,-0.014 -5.33,1.734 -10.84,3.527 -13.269,0.608 -2.431,-2.919 0.33,-8.014 3.003,-12.941 2.988,-5.512 6.077,-11.208 2.785,-15.174 -3.302,-3.966 -9.471,-1.964 -15.436,-0.027 -5.333,1.73 -10.845,3.52 -13.28,0.593 -2.437,-2.923 0.326,-8.021 2.993,-12.952 2.99,-5.516 6.073,-11.212 2.775,-15.184 -0.354,-0.423 -0.984,-0.48 -1.41,-0.129 -0.42,0.358 -0.476,0.987 -0.129,1.41 2.445,2.923 -0.322,8.024 -2.993,12.952 -2.99,5.515 -6.071,11.218 -2.775,15.184 3.302,3.966 9.47,1.965 15.436,0.028 5.333,-1.73 10.845,-3.521 13.28,-0.594 2.431,2.913 -0.33,8.012 -3.003,12.938 -2.986,5.515 -6.081,11.211 -2.785,15.175 3.296,3.96 9.463,1.954 15.426,0.015 5.329,-1.734 10.84,-3.526 13.271,-0.607 2.423,2.91 -0.334,8.01 -3.007,12.937 -2.992,5.51 -6.083,11.204 -2.787,15.172 3.294,3.956 9.459,1.946 15.42,0.006 5.327,-1.736 10.836,-3.531 13.259,-0.617 0.353,0.425 0.984,0.482 1.408,0.13 C -0.123,0.57 0,0.287 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1943.4697,712.2052)"
+         clip-path="url(#clipPath386)"
+         id="path538" />
+      <path
+         d="m 0,0 c 0,-0.1 -0.014,-0.199 -0.045,-0.299 -0.576,-1.835 -2.72,-1.997 -4.61,-2.14 -1.133,-0.086 -2.681,-0.201 -2.851,-0.744 -0.188,-0.539 1.035,-1.527 1.913,-2.245 1.469,-1.197 3.146,-2.553 2.559,-4.39 -0.575,-1.837 -2.719,-2.001 -4.609,-2.144 -1.133,-0.086 -2.683,-0.203 -2.853,-0.748 -0.195,-0.543 1.033,-1.527 1.914,-2.245 1.47,-1.197 3.138,-2.557 2.56,-4.392 -0.578,-1.839 -2.72,-2.003 -4.612,-2.148 -1.133,-0.086 -2.685,-0.205 -2.855,-0.751 -0.199,-0.54 1.033,-1.532 1.913,-2.25 1.469,-1.197 3.146,-2.554 2.556,-4.396 -0.163,-0.527 -0.726,-0.82 -1.251,-0.654 -0.527,0.164 -0.824,0.727 -0.654,1.252 0.144,0.562 -1.033,1.531 -1.916,2.249 -1.468,1.197 -3.14,2.558 -2.556,4.396 0.576,1.839 2.718,2.003 4.61,2.148 1.133,0.086 2.685,0.205 2.855,0.752 0.178,0.519 -1.033,1.525 -1.913,2.245 -1.469,1.197 -3.142,2.554 -2.559,4.392 0.575,1.837 2.719,2.001 4.609,2.144 1.133,0.085 2.683,0.203 2.853,0.748 0.171,0.54 -1.031,1.525 -1.914,2.241 -1.468,1.199 -3.146,2.564 -2.558,4.394 0.574,1.835 2.718,1.998 4.608,2.14 1.133,0.086 2.681,0.201 2.851,0.744 0.166,0.527 0.726,0.82 1.254,0.656 C -0.274,0.82 0,0.426 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1909.2723,847.7548)"
+         clip-path="url(#clipPath387)"
+         id="path539" />
+      <path
+         d="m 0,0 c 0,-1.512 -0.449,-3.232 -0.892,-4.923 -0.686,-2.622 -1.398,-5.338 -0.094,-6.297 0.445,-0.324 0.543,-0.953 0.211,-1.398 -0.328,-0.443 -0.953,-0.539 -1.398,-0.211 -2.392,1.763 -1.51,5.141 -0.652,8.412 0.685,2.624 1.398,5.337 0.093,6.295 -1.302,0.959 -3.684,-0.521 -5.986,-1.954 -2.871,-1.785 -5.839,-3.63 -8.233,-1.865 -2.396,1.763 -1.51,5.143 -0.656,8.414 0.683,2.626 1.396,5.341 0.09,6.299 -1.303,0.961 -3.687,-0.521 -5.991,-1.952 -2.87,-1.785 -5.836,-3.628 -8.233,-1.865 -2.394,1.763 -1.515,5.143 -0.664,8.418 0.686,2.626 1.395,5.341 0.084,6.305 -1.306,0.963 -3.69,-0.517 -5.996,-1.949 -2.873,-1.782 -5.84,-3.624 -8.239,-1.859 -0.443,0.329 -0.538,0.955 -0.21,1.398 0.326,0.444 0.953,0.539 1.398,0.211 1.306,-0.963 3.69,0.518 5.996,1.949 2.871,1.783 5.841,3.626 8.239,1.859 2.398,-1.763 1.515,-5.145 0.664,-8.418 -0.684,-2.626 -1.392,-5.338 -0.084,-6.305 1.302,-0.961 3.686,0.521 5.991,1.953 2.87,1.784 5.836,3.628 8.232,1.865 2.394,-1.766 1.507,-5.148 0.656,-8.415 -0.683,-2.626 -1.396,-5.336 -0.09,-6.299 1.303,-0.961 3.685,0.521 5.989,1.954 2.869,1.783 5.837,3.629 8.231,1.865 C -0.39,2.638 0,1.41 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2086.4135,38.169733)"
+         clip-path="url(#clipPath388)"
+         id="path540" />
+      <path
+         d="m 0,0 c 0,-1.867 -1.541,-3.778 -2.937,-5.512 -1.464,-1.824 -2.988,-3.709 -2.327,-4.87 0.269,-0.485 0.099,-1.092 -0.379,-1.363 -0.483,-0.272 -1.092,-0.102 -1.363,0.378 -1.32,2.359 0.716,4.878 2.513,7.108 1.464,1.822 2.972,3.702 2.328,4.87 -0.657,1.166 -3.057,0.842 -5.376,0.53 -2.839,-0.385 -6.059,-0.819 -7.384,1.524 -1.327,2.347 0.714,4.878 2.51,7.114 1.464,1.82 2.991,3.694 2.327,4.876 -0.657,1.164 -3.055,0.839 -5.375,0.527 -2.842,-0.383 -6.063,-0.816 -7.385,1.531 -1.326,2.349 0.712,4.884 2.505,7.116 1.467,1.822 2.987,3.698 2.324,4.879 -0.66,1.17 -3.06,0.848 -5.38,0.537 -2.843,-0.382 -6.063,-0.814 -7.389,1.533 -0.269,0.478 -0.101,1.092 0.379,1.363 0.48,0.272 1.091,0.102 1.363,-0.379 0.66,-1.169 3.06,-0.847 5.379,-0.537 2.843,0.383 6.063,0.814 7.39,-1.533 1.325,-2.356 -0.709,-4.881 -2.506,-7.115 -1.468,-1.826 -2.984,-3.718 -2.324,-4.882 0.659,-1.168 3.056,-0.843 5.376,-0.531 2.841,0.383 6.061,0.818 7.385,-1.527 1.322,-2.347 -0.715,-4.878 -2.511,-7.112 -1.469,-1.825 -2.986,-3.719 -2.325,-4.875 0.655,-1.166 3.055,-0.842 5.375,-0.529 2.839,0.384 6.059,0.818 7.383,-1.526 C -0.129,1.07 0,0.537 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2234.5073,587.29627)"
+         clip-path="url(#clipPath389)"
+         id="path541" />
+      <path
+         d="m 0,0 c 0.002,-2.425 -2.575,-4.052 -5.075,-5.63 -2.16,-1.358 -4.366,-2.727 -4.116,-4.237 0.092,-0.535 -0.256,-1.064 -0.801,-1.164 -0.543,-0.101 -1.064,0.258 -1.164,0.801 -0.521,2.787 2.291,4.575 5.013,6.294 2.158,1.359 4.352,2.743 4.116,4.237 -0.273,1.47 -2.861,1.984 -5.364,2.48 -3.155,0.627 -6.418,1.275 -6.938,4.079 -0.523,2.771 2.289,4.577 5.011,6.295 2.158,1.363 4.386,2.757 4.116,4.243 -0.273,1.473 -2.861,1.988 -5.364,2.484 -3.156,0.627 -6.42,1.276 -6.94,4.079 -0.527,2.818 2.291,4.587 5.011,6.308 2.157,1.363 4.386,2.788 4.114,4.249 -0.275,1.478 -2.862,1.993 -5.366,2.491 -3.155,0.629 -6.418,1.279 -6.94,4.085 -0.097,0.539 0.258,1.066 0.799,1.166 0.543,0.101 1.066,-0.256 1.166,-0.799 0.275,-1.476 2.863,-1.991 5.366,-2.49 3.155,-0.628 6.42,-1.278 6.939,-4.088 0.526,-2.787 -2.288,-4.581 -5.008,-6.304 -2.158,-1.364 -4.353,-2.753 -4.116,-4.253 0.273,-1.47 2.862,-1.985 5.366,-2.481 3.155,-0.627 6.418,-1.275 6.937,-4.081 0.535,-2.775 -2.288,-4.577 -5.012,-6.3 -2.156,-1.361 -4.39,-2.788 -4.114,-4.239 C -12.091,5.753 -9.504,5.239 -7,4.743 -3.845,4.116 -0.582,3.468 -0.062,0.664 -0.02,0.437 0,0.215 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2333.9453,1096.4501)"
+         clip-path="url(#clipPath390)"
+         id="path542" />
+      <path
+         d="m 0,0 c 0,-0.435 -0.285,-0.836 -0.725,-0.961 -2.405,-0.691 -2.807,-4.682 -3.198,-8.54 -0.455,-4.525 -0.927,-9.202 -4.637,-10.266 -3.707,-1.064 -6.589,2.648 -9.375,6.239 -2.379,3.066 -4.837,6.235 -7.245,5.543 -2.4,-0.689 -2.802,-4.68 -3.189,-8.54 -0.453,-4.521 -0.923,-9.195 -4.625,-10.26 -3.703,-1.064 -6.581,2.65 -9.365,6.243 -2.377,3.066 -4.833,6.235 -7.235,5.545 -2.398,-0.689 -2.798,-4.678 -3.185,-8.538 -0.453,-4.523 -0.921,-9.197 -4.624,-10.262 -3.698,-1.062 -6.575,2.654 -9.357,6.247 -2.374,3.066 -4.829,6.237 -7.227,5.547 -0.529,-0.152 -1.084,0.155 -1.236,0.686 -0.162,0.523 0.152,1.084 0.685,1.236 3.699,1.062 6.577,-2.652 9.359,-6.245 2.373,-3.068 4.828,-6.237 7.226,-5.549 2.397,0.689 2.798,4.68 3.184,8.539 0.453,4.522 0.922,9.199 4.624,10.261 3.702,1.064 6.581,-2.65 9.365,-6.243 2.377,-3.065 4.833,-6.235 7.235,-5.545 2.4,0.689 2.8,4.68 3.187,8.539 0.455,4.522 0.923,9.197 4.628,10.261 3.706,1.064 6.588,-2.648 9.374,-6.239 2.379,-3.065 4.837,-6.234 7.245,-5.544 2.407,0.692 2.81,4.683 3.2,8.544 0.455,4.522 0.928,9.199 4.636,10.263 0.529,0.152 1.083,-0.154 1.236,-0.685 C -0.012,0.184 0,0.092 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2072.4327,419.00693)"
+         clip-path="url(#clipPath391)"
+         id="path543" />
+      <path
+         d="m 0,0 c 0,-0.27 -0.108,-0.537 -0.32,-0.734 -2.738,-2.533 -6.831,-0.58 -10.787,1.308 -3.354,1.602 -6.825,3.257 -8.566,1.646 -1.746,-1.611 -0.369,-5.204 0.966,-8.675 1.572,-4.097 3.193,-8.33 0.461,-10.859 -2.741,-2.533 -6.834,-0.582 -10.792,1.304 -3.359,1.599 -6.831,3.255 -8.575,1.64 -1.745,-1.614 -0.367,-5.203 0.967,-8.676 1.572,-4.096 3.198,-8.328 0.459,-10.862 -2.744,-2.537 -6.838,-0.588 -10.8,1.296 -3.359,1.6 -6.833,3.252 -8.582,1.633 -1.756,-1.619 -0.373,-5.21 0.958,-8.683 1.568,-4.092 3.193,-8.331 0.451,-10.867 -0.405,-0.375 -1.038,-0.35 -1.413,0.054 -0.373,0.411 -0.348,1.041 0.055,1.414 1.755,1.621 0.374,5.21 -0.959,8.683 -1.57,4.092 -3.197,8.327 -0.451,10.867 2.743,2.539 6.84,0.59 10.8,-1.296 3.361,-1.598 6.834,-3.252 8.582,-1.633 1.744,1.609 0.367,5.206 -0.967,8.676 -1.571,4.097 -3.2,8.33 -0.458,10.863 2.741,2.533 6.834,0.582 10.792,-1.305 3.359,-1.599 6.83,-3.255 8.574,-1.64 1.744,1.607 0.365,5.202 -0.968,8.674 -1.57,4.091 -3.201,8.328 -0.459,10.861 2.737,2.532 6.83,0.58 10.786,-1.309 3.355,-1.601 6.825,-3.257 8.567,-1.646 0.406,0.375 1.038,0.35 1.413,-0.055 C -0.088,0.486 0,0.242 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2326.0799,621.4708)"
+         clip-path="url(#clipPath392)"
+         id="path544" />
+      <path
+         d="m 0,0 c 0,-0.226 -0.076,-0.453 -0.232,-0.641 -1.91,-2.292 -5.249,-1.202 -8.481,-0.15 -2.597,0.848 -5.282,1.724 -6.326,0.471 -1.049,-1.256 0.302,-3.737 1.604,-6.139 1.615,-2.992 3.291,-6.081 1.383,-8.376 -1.914,-2.294 -5.254,-1.206 -8.486,-0.154 -2.599,0.848 -5.284,1.722 -6.331,0.467 -1.043,-1.254 0.299,-3.737 1.603,-6.141 1.619,-2.99 3.295,-6.077 1.379,-8.375 -1.914,-2.298 -5.257,-1.213 -8.488,-0.162 -2.601,0.845 -5.288,1.718 -6.339,0.459 -1.041,-1.252 0.299,-3.746 1.599,-6.147 1.617,-2.99 3.291,-6.081 1.375,-8.381 -0.351,-0.424 -0.982,-0.48 -1.408,-0.127 -0.423,0.355 -0.478,0.986 -0.127,1.408 1.043,1.255 -0.298,3.743 -1.599,6.147 -1.619,2.989 -3.29,6.082 -1.374,8.381 1.915,2.298 5.258,1.212 8.49,0.161 2.599,-0.845 5.288,-1.718 6.336,-0.458 1.045,1.254 -0.301,3.737 -1.603,6.141 -1.619,2.992 -3.292,6.084 -1.378,8.375 1.911,2.294 5.252,1.207 8.484,0.154 2.599,-0.847 5.284,-1.722 6.33,-0.467 1.047,1.26 -0.302,3.742 -1.605,6.142 -1.618,2.987 -3.296,6.078 -1.38,8.373 1.909,2.292 5.251,1.203 8.482,0.15 2.597,-0.847 5.282,-1.724 6.325,-0.47 0.351,0.423 0.982,0.48 1.408,0.126 C -0.123,0.57 0,0.285 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2603.5708,926.03867)"
+         clip-path="url(#clipPath393)"
+         id="path545" />
+      <path
+         d="m 0,0 c 0,-0.736 -0.18,-1.459 -0.595,-2.167 -1.801,-3.064 -6.036,-2.42 -10.135,-1.795 -3.438,0.523 -6.994,1.064 -8.109,-0.832 -1.107,-1.896 1.089,-4.735 3.224,-7.482 2.536,-3.277 5.172,-6.661 3.364,-9.721 -1.796,-3.06 -6.032,-2.413 -10.127,-1.787 -3.438,0.526 -6.994,1.068 -8.107,-0.824 -1.107,-1.892 1.095,-4.733 3.226,-7.48 2.54,-3.273 5.172,-6.655 3.366,-9.719 -1.794,-3.058 -6.03,-2.409 -10.124,-1.781 -3.437,0.527 -6.991,1.072 -8.102,-0.816 -0.279,-0.477 -0.892,-0.637 -1.367,-0.355 -0.48,0.281 -0.633,0.9 -0.355,1.366 1.796,3.059 6.032,2.41 10.126,1.781 3.437,-0.527 6.989,-1.071 8.1,0.817 1.113,1.901 -1.096,4.735 -3.224,7.48 -2.54,3.275 -5.165,6.667 -3.368,9.719 1.798,3.061 6.033,2.415 10.13,1.789 3.437,-0.526 6.991,-1.069 8.104,0.821 1.105,1.897 -1.091,4.736 -3.224,7.483 -2.534,3.275 -5.169,6.659 -3.365,9.721 1.801,3.065 6.036,2.421 10.135,1.796 3.439,-0.523 6.994,-1.064 8.11,0.832 1.12,1.91 -1.09,4.743 -3.22,7.493 -2.539,3.276 -5.163,6.67 -3.361,9.726 0.279,0.476 0.892,0.636 1.367,0.355 0.48,-0.279 0.632,-0.898 0.355,-1.367 -1.111,-1.908 1.09,-4.741 3.22,-7.49 C -2.003,5.042 0,2.455 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1758.2233,536.37293)"
+         clip-path="url(#clipPath394)"
+         id="path546" />
+      <path
+         d="m 0,0 c 0,-0.326 -0.16,-0.648 -0.457,-0.84 -3.189,-2.062 -6.961,0.617 -10.611,3.208 -3.107,2.205 -6.319,4.486 -8.369,3.158 -2.05,-1.326 -1.291,-5.192 -0.553,-8.93 0.866,-4.389 1.765,-8.931 -1.429,-10.997 -3.19,-2.064 -6.967,0.613 -10.619,3.202 -3.106,2.205 -6.32,4.484 -8.373,3.156 -2.056,-1.33 -1.291,-5.196 -0.556,-8.934 0.867,-4.391 1.757,-8.933 -1.432,-10.997 -3.194,-2.068 -6.972,0.609 -10.626,3.196 -3.11,2.203 -6.324,4.48 -8.385,3.148 -2.056,-1.33 -1.3,-5.198 -0.564,-8.939 0.865,-4.392 1.755,-8.936 -1.439,-11.002 -0.463,-0.299 -1.082,-0.166 -1.383,0.297 -0.301,0.461 -0.169,1.082 0.297,1.383 2.062,1.333 1.301,5.201 0.562,8.935 -0.859,4.397 -1.753,8.937 1.441,11.005 3.195,2.068 6.974,-0.609 10.627,-3.196 3.111,-2.203 6.325,-4.48 8.385,-3.148 2.054,1.33 1.291,5.196 0.556,8.934 -0.869,4.387 -1.761,8.931 1.432,10.997 3.19,2.064 6.965,-0.613 10.614,-3.202 3.109,-2.205 6.323,-4.486 8.377,-3.156 2.051,1.326 1.291,5.192 0.553,8.93 -0.863,4.393 -1.761,8.933 1.429,10.997 3.189,2.064 6.964,-0.617 10.613,-3.206 3.105,-2.207 6.317,-4.485 8.367,-3.16 C -1.08,1.138 -0.461,1.005 -0.16,0.543 -0.051,0.375 0,0.187 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1730.8003,707.2136)"
+         clip-path="url(#clipPath395)"
+         id="path547" />
+      <path
+         d="m 0,0 c 0,-0.388 -0.229,-0.759 -0.611,-0.921 -3.589,-1.516 -3.468,-7.423 -3.357,-13.158 0.131,-6.389 0.258,-12.995 -4.579,-15.041 -4.835,-2.044 -9.484,2.652 -13.979,7.193 -4.027,4.068 -8.192,8.274 -11.781,6.757 -3.579,-1.515 -3.46,-7.438 -3.343,-13.151 0.139,-6.389 0.266,-12.992 -4.565,-15.036 -4.827,-2.041 -9.472,2.658 -13.964,7.199 -4.024,4.07 -8.183,8.278 -11.764,6.763 -3.578,-1.514 -3.457,-7.421 -3.339,-13.15 0.132,-6.395 0.265,-12.995 -4.564,-15.035 -4.821,-2.039 -9.463,2.661 -13.952,7.205 -4.02,4.069 -8.178,8.277 -11.753,6.766 -0.507,-0.215 -1.093,0.023 -1.31,0.533 -0.207,0.504 0.019,1.094 0.533,1.31 4.821,2.039 9.463,-2.661 13.952,-7.205 4.02,-4.069 8.178,-8.277 11.753,-6.766 3.581,1.513 3.466,7.438 3.341,13.151 -0.131,6.392 -0.267,12.992 4.561,15.034 4.827,2.04 9.473,-2.658 13.964,-7.2 4.024,-4.069 8.184,-8.277 11.765,-6.762 3.579,1.514 3.464,7.428 3.343,13.152 -0.129,6.389 -0.264,12.993 4.565,15.035 4.835,2.045 9.484,-2.652 13.979,-7.193 4.027,-4.068 8.192,-8.274 11.781,-6.757 3.589,1.517 3.472,7.438 3.357,13.159 -0.124,6.395 -0.258,12.991 4.579,15.04 0.507,0.215 1.093,-0.023 1.31,-0.533 C -0.026,0.262 0,0.131 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1837.846,941.97787)"
+         clip-path="url(#clipPath396)"
+         id="path548" />
+      <path
+         d="m 0,0 c 0,-0.041 -0.002,-0.08 -0.008,-0.119 -0.064,-0.549 -0.562,-0.941 -1.109,-0.875 -5.614,0.666 -7.465,7.598 -9.256,14.301 -1.619,6.062 -3.294,12.328 -7.558,12.835 -4.273,0.506 -7.372,-5.194 -10.367,-10.706 C -31.612,9.338 -35.037,3.032 -40.655,3.7 c -5.618,0.666 -7.473,7.598 -9.267,14.302 -1.623,6.061 -3.3,12.329 -7.573,12.836 -4.274,0.508 -7.373,-5.192 -10.368,-10.704 -3.316,-6.098 -6.743,-12.403 -12.363,-11.736 -5.627,0.668 -7.486,7.6 -9.285,14.304 -1.626,6.063 -3.308,12.331 -7.59,12.841 -4.284,0.507 -7.385,-5.192 -10.386,-10.705 -3.317,-6.098 -6.75,-12.401 -12.376,-11.734 -0.551,0.065 -0.932,0.614 -0.875,1.109 0.065,0.549 0.562,0.941 1.109,0.875 4.284,-0.507 7.385,5.192 10.387,10.705 3.317,6.098 6.75,12.401 12.376,11.733 5.627,-0.667 7.488,-7.601 9.287,-14.305 1.626,-6.061 3.307,-12.329 7.587,-12.839 4.275,-0.508 7.376,5.194 10.371,10.707 3.316,6.096 6.743,12.401 12.361,11.733 5.619,-0.665 7.475,-7.597 9.269,-14.303 1.623,-6.061 3.3,-12.327 7.571,-12.835 4.272,-0.506 7.371,5.194 10.366,10.707 3.314,6.098 6.739,12.403 12.357,11.735 5.614,-0.666 7.465,-7.598 9.255,-14.301 C -6.823,7.764 -5.147,1.498 -0.883,0.99 -0.373,0.929 0,0.498 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2306.7564,783.53747)"
+         clip-path="url(#clipPath397)"
+         id="path549" />
+      <path
+         d="m 0,0 c 0,-0.467 -0.328,-0.885 -0.805,-0.979 -2.653,-0.527 -3.436,-4.744 -4.194,-8.822 -0.878,-4.733 -1.789,-9.626 -5.77,-10.419 -3.982,-0.793 -6.696,3.38 -9.322,7.414 -2.262,3.476 -4.601,7.071 -7.254,6.543 -2.648,-0.527 -3.429,-4.742 -4.185,-8.82 -0.877,-4.733 -1.783,-9.625 -5.76,-10.417 -3.976,-0.791 -6.686,3.38 -9.309,7.416 -2.259,3.478 -4.594,7.073 -7.242,6.545 -2.646,-0.527 -3.427,-4.742 -4.181,-8.818 -0.876,-4.733 -1.783,-9.627 -5.758,-10.417 -3.972,-0.791 -6.681,3.382 -9.301,7.418 -2.257,3.478 -4.591,7.073 -7.233,6.547 -0.541,-0.107 -1.068,0.244 -1.175,0.785 -0.11,0.533 0.24,1.068 0.785,1.176 3.972,0.79 6.68,-3.382 9.3,-7.418 2.258,-3.478 4.591,-7.073 7.233,-6.548 2.648,0.527 3.429,4.743 4.183,8.821 0.876,4.731 1.781,9.624 5.756,10.415 3.976,0.793 6.688,-3.38 9.311,-7.416 2.259,-3.478 4.594,-7.073 7.24,-6.546 2.648,0.528 3.429,4.744 4.185,8.821 0.876,4.733 1.782,9.624 5.76,10.417 3.981,0.793 6.696,-3.38 9.322,-7.414 2.261,-3.476 4.601,-7.071 7.255,-6.544 2.653,0.53 3.436,4.746 4.194,8.825 0.878,4.731 1.788,9.624 5.77,10.417 C -0.654,1.089 -0.127,0.738 -0.02,0.197 -0.006,0.131 0,0.066 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1402.7639,1010.2119)"
+         clip-path="url(#clipPath398)"
+         id="path550" />
+      <path
+         d="m 0,0 c 0,-0.045 -0.002,-0.088 -0.008,-0.133 -0.072,-0.546 -0.574,-0.931 -1.123,-0.861 -3.706,0.486 -4.827,4.895 -5.911,9.16 -0.919,3.618 -1.87,7.36 -4.235,7.67 -2.367,0.311 -4.251,-3.058 -6.075,-6.317 -2.148,-3.841 -4.368,-7.812 -8.08,-7.326 -3.712,0.486 -4.835,4.897 -5.92,9.162 -0.92,3.618 -1.873,7.359 -4.242,7.67 -2.366,0.311 -4.252,-3.058 -6.076,-6.317 -2.148,-3.841 -4.37,-7.813 -8.083,-7.326 -3.717,0.488 -4.842,4.897 -5.932,9.161 -0.923,3.619 -1.878,7.362 -4.253,7.673 -2.374,0.312 -4.262,-3.058 -6.088,-6.317 -2.15,-3.839 -4.374,-7.809 -8.092,-7.323 -0.546,0.072 -0.926,0.582 -0.861,1.123 0.072,0.547 0.574,0.931 1.123,0.861 2.372,-0.312 4.26,3.058 6.086,6.315 2.15,3.841 4.376,7.81 8.094,7.325 3.716,-0.489 4.841,-4.898 5.93,-9.163 0.924,-3.618 1.879,-7.361 4.253,-7.672 2.369,-0.31 4.255,3.06 6.079,6.319 2.148,3.839 4.37,7.811 8.082,7.325 3.71,-0.489 4.833,-4.898 5.919,-9.16 0.919,-3.62 1.872,-7.362 4.243,-7.672 2.366,-0.311 4.251,3.058 6.075,6.317 2.148,3.841 4.368,7.812 8.08,7.326 3.708,-0.488 4.829,-4.897 5.913,-9.162 C -4.183,5.04 -3.234,1.298 -0.869,0.99 -0.367,0.924 0,0.494 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2232.3987,65.124533)"
+         clip-path="url(#clipPath399)"
+         id="path551" />
+      <path
+         d="m 0,0 c 0,-0.07 -0.008,-0.143 -0.024,-0.215 -0.119,-0.539 -0.652,-0.881 -1.19,-0.762 -0.969,0.213 -2.112,-1.464 -3.119,-2.942 -1.363,-2.006 -2.91,-4.277 -5.198,-3.771 -2.291,0.506 -2.738,3.218 -3.13,5.61 -0.291,1.765 -0.619,3.767 -1.59,3.982 -0.964,0.213 -2.105,-1.463 -3.11,-2.943 -1.363,-2.003 -2.908,-4.276 -5.195,-3.771 -2.288,0.506 -2.731,3.216 -3.124,5.609 -0.289,1.765 -0.615,3.766 -1.579,3.979 -0.967,0.213 -2.107,-1.464 -3.113,-2.944 -1.361,-2.004 -2.906,-4.277 -5.192,-3.771 -2.287,0.506 -2.73,3.218 -3.121,5.61 -0.286,1.763 -0.613,3.764 -1.577,3.977 -0.535,0.121 -0.869,0.643 -0.76,1.194 0.119,0.539 0.652,0.878 1.193,0.759 2.285,-0.505 2.728,-3.218 3.119,-5.61 0.287,-1.763 0.613,-3.765 1.577,-3.977 0.963,-0.214 2.103,1.462 3.107,2.942 1.363,2.006 2.907,4.278 5.196,3.773 2.289,-0.506 2.732,-3.216 3.124,-5.608 0.289,-1.766 0.616,-3.767 1.58,-3.98 0.967,-0.213 2.107,1.463 3.113,2.943 1.363,2.003 2.907,4.276 5.194,3.77 2.29,-0.505 2.738,-3.218 3.13,-5.61 0.291,-1.765 0.619,-3.766 1.59,-3.981 0.966,-0.213 2.106,1.462 3.114,2.942 1.363,2.004 2.909,4.277 5.2,3.771 C -0.318,0.873 0,0.461 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2396.1135,128.2556)"
+         clip-path="url(#clipPath400)"
+         id="path552" />
+      <path
+         d="m 0,0 c 0,-0.473 -0.338,-0.893 -0.818,-0.982 -2.093,-0.383 -2.784,-3.812 -3.452,-7.128 -0.801,-3.968 -1.627,-8.07 -5.052,-8.699 -3.425,-0.626 -5.653,2.915 -7.809,6.343 -1.802,2.86 -3.663,5.82 -5.756,5.436 -2.088,-0.383 -2.777,-3.81 -3.443,-7.124 -0.799,-3.967 -1.622,-8.07 -5.044,-8.699 -3.419,-0.626 -5.645,2.918 -7.799,6.344 -1.798,2.863 -3.657,5.821 -5.744,5.439 -2.086,-0.383 -2.775,-3.81 -3.441,-7.124 -0.797,-3.967 -1.621,-8.07 -5.04,-8.697 -3.417,-0.627 -5.641,2.917 -7.793,6.344 -1.796,2.863 -3.655,5.823 -5.739,5.44 -0.542,-0.099 -1.064,0.262 -1.164,0.805 -0.095,0.527 0.262,1.062 0.805,1.164 3.417,0.625 5.641,-2.92 7.791,-6.344 1.799,-2.863 3.656,-5.823 5.741,-5.441 2.085,0.381 2.773,3.808 3.439,7.122 0.796,3.968 1.62,8.072 5.042,8.699 3.418,0.627 5.645,-2.917 7.799,-6.344 1.798,-2.863 3.657,-5.821 5.744,-5.438 2.088,0.382 2.777,3.809 3.443,7.125 0.798,3.968 1.623,8.07 5.044,8.697 3.423,0.627 5.65,-2.915 7.806,-6.34 1.803,-2.863 3.665,-5.823 5.759,-5.439 2.091,0.383 2.782,3.812 3.45,7.126 0.801,3.967 1.627,8.07 5.05,8.701 0.545,0.099 1.064,-0.26 1.165,-0.802 C -0.006,0.121 0,0.06 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1862.3999,640.98427)"
+         clip-path="url(#clipPath401)"
+         id="path553" />
+      <path
+         d="m 0,0 c 0,-0.19 -0.053,-0.379 -0.164,-0.549 -0.303,-0.461 -0.922,-0.59 -1.384,-0.287 -2.311,1.515 -1.637,4.8 -1.051,7.694 0.486,2.384 0.988,4.848 -0.187,5.624 -1.178,0.771 -3.24,-0.674 -5.234,-2.07 -2.421,-1.697 -5.167,-3.621 -7.478,-2.105 -2.312,1.517 -1.642,4.801 -1.057,7.697 0.486,2.382 0.986,4.852 -0.191,5.626 -1.179,0.773 -3.242,-0.672 -5.235,-2.068 -2.424,-1.697 -5.169,-3.618 -7.481,-2.103 -2.31,1.517 -1.648,4.799 -1.06,7.699 0.48,2.386 0.986,4.855 -0.199,5.63 -1.182,0.775 -3.246,-0.67 -5.243,-2.066 -2.421,-1.695 -5.169,-3.615 -7.483,-2.097 -0.465,0.302 -0.592,0.919 -0.287,1.384 0.302,0.461 0.921,0.59 1.384,0.287 1.182,-0.775 3.244,0.67 5.239,2.064 2.424,1.695 5.171,3.617 7.487,2.099 2.314,-1.515 1.65,-4.795 1.06,-7.699 -0.482,-2.386 -0.984,-4.857 0.199,-5.63 1.18,-0.773 3.242,0.672 5.236,2.068 2.423,1.697 5.168,3.619 7.48,2.103 2.31,-1.515 1.642,-4.801 1.055,-7.695 -0.484,-2.387 -0.984,-4.852 0.193,-5.628 1.177,-0.771 3.24,0.674 5.233,2.07 2.422,1.697 5.167,3.62 7.479,2.105 2.306,-1.512 1.638,-4.796 1.05,-7.694 C -1.127,4.073 -1.628,1.607 -0.451,0.836 -0.158,0.644 0,0.324 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2314.3535,1190.7303)"
+         clip-path="url(#clipPath402)"
+         id="path554" />
+      <path
+         d="m 0,0 c 0,-0.096 -0.014,-0.193 -0.043,-0.289 -0.16,-0.529 -0.716,-0.828 -1.246,-0.668 -2.919,0.883 -5.889,-2.839 -8.761,-6.436 -3.287,-4.118 -6.686,-8.375 -10.902,-7.102 -4.216,1.273 -4.689,6.7 -5.147,11.951 -0.399,4.585 -0.812,9.328 -3.732,10.208 -2.913,0.881 -5.879,-2.841 -8.748,-6.438 -3.284,-4.12 -6.68,-8.379 -10.892,-7.107 -4.21,1.271 -4.679,6.699 -5.134,11.946 -0.396,4.585 -0.806,9.326 -3.717,10.206 -2.912,0.879 -5.878,-2.842 -8.747,-6.441 -3.284,-4.119 -6.678,-8.379 -10.888,-7.108 -4.206,1.271 -4.672,6.698 -5.125,11.945 -0.395,4.585 -0.803,9.323 -3.71,10.202 -0.528,0.16 -0.822,0.727 -0.668,1.246 0.16,0.529 0.716,0.828 1.246,0.668 4.206,-1.269 4.672,-6.696 5.125,-11.944 0.395,-4.583 0.803,-9.325 3.71,-10.203 2.912,-0.879 5.878,2.843 8.746,6.441 3.285,4.119 6.679,8.379 10.889,7.108 4.209,-1.271 4.678,-6.699 5.133,-11.946 0.397,-4.585 0.806,-9.326 3.718,-10.207 2.916,-0.881 5.882,2.841 8.75,6.44 3.284,4.118 6.68,8.377 10.89,7.106 4.216,-1.273 4.689,-6.7 5.147,-11.951 0.399,-4.584 0.813,-9.328 3.732,-10.208 2.919,-0.883 5.889,2.839 8.761,6.436 3.287,4.118 6.686,8.375 10.902,7.102 C -0.279,0.826 0,0.429 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2615.4481,711.9108)"
+         clip-path="url(#clipPath403)"
+         id="path555" />
+      <path
+         d="m 0,0 c 0,-0.238 -0.084,-0.474 -0.254,-0.666 -2.697,-3.021 -7.371,-1.316 -11.89,0.33 -3.893,1.42 -7.92,2.888 -9.714,0.879 -1.795,-2.007 0.117,-5.85 1.964,-9.559 2.146,-4.305 4.362,-8.755 1.668,-11.782 -2.701,-3.022 -7.375,-1.322 -11.896,0.324 -3.895,1.42 -7.924,2.886 -9.72,0.873 -1.803,-2.017 0.115,-5.852 1.962,-9.56 2.148,-4.308 4.37,-8.754 1.666,-11.785 -2.703,-3.028 -7.382,-1.327 -11.904,0.315 -3.897,1.416 -7.926,2.88 -9.728,0.863 -1.804,-2.013 0.109,-5.856 1.954,-9.568 2.147,-4.312 4.361,-8.762 1.658,-11.792 -0.367,-0.413 -0.999,-0.447 -1.411,-0.08 -0.412,0.367 -0.446,0.999 -0.081,1.411 1.807,2.023 -0.109,5.858 -1.954,9.569 -2.144,4.311 -4.364,8.765 -1.658,11.792 2.703,3.028 7.381,1.327 11.904,-0.315 3.897,-1.415 7.925,-2.88 9.728,-0.863 1.802,2.017 -0.113,5.85 -1.962,9.561 -2.146,4.307 -4.365,8.761 -1.666,11.784 2.7,3.023 7.375,1.322 11.896,-0.324 3.895,-1.42 7.923,-2.886 9.72,-0.873 1.8,2.021 -0.115,5.852 -1.965,9.558 -2.145,4.308 -4.364,8.758 -1.667,11.783 2.697,3.02 7.371,1.316 11.89,-0.331 3.893,-1.419 7.92,-2.887 9.714,-0.878 0.367,0.412 1,0.447 1.412,0.08 C -0.113,0.549 0,0.276 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1707.532,255.46373)"
+         clip-path="url(#clipPath404)"
+         id="path556" />
+      <path
+         d="m 0,0 c 0,-0.062 -0.006,-0.125 -0.018,-0.188 -0.576,-3.065 -4.203,-3.776 -7.713,-4.463 -2.854,-0.559 -5.807,-1.139 -6.133,-2.873 -0.324,-1.726 2.214,-3.347 4.671,-4.905 3.021,-1.915 6.129,-3.909 5.565,-6.965 -0.576,-3.068 -4.204,-3.78 -7.713,-4.47 -2.855,-0.56 -5.807,-1.14 -6.135,-2.878 -0.33,-1.757 2.216,-3.349 4.671,-4.907 3.02,-1.92 6.131,-3.921 5.567,-6.967 -0.577,-3.074 -4.207,-3.788 -7.715,-4.48 -2.857,-0.562 -5.81,-1.144 -6.138,-2.886 -0.326,-1.724 2.216,-3.354 4.671,-4.917 3.019,-1.919 6.132,-3.905 5.563,-6.972 -0.101,-0.543 -0.625,-0.901 -1.165,-0.799 -0.545,0.101 -0.901,0.65 -0.799,1.166 0.343,1.755 -2.214,3.356 -4.671,4.918 -3.021,1.916 -6.155,3.898 -5.563,6.973 0.576,3.074 4.206,3.789 7.715,4.48 2.856,0.562 5.809,1.144 6.137,2.886 0.346,1.744 -2.216,3.349 -4.673,4.909 -3.02,1.918 -6.143,3.925 -5.565,6.965 0.576,3.07 4.207,3.783 7.715,4.472 2.855,0.56 5.807,1.14 6.134,2.876 0.347,1.759 -2.213,3.349 -4.671,4.907 -3.021,1.914 -6.139,3.888 -5.565,6.965 0.576,3.066 4.204,3.777 7.713,4.464 2.855,0.559 5.807,1.139 6.133,2.873 0.102,0.54 0.625,0.898 1.168,0.796 C -0.334,0.89 0,0.471 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2007.0803,1174.6012)"
+         clip-path="url(#clipPath405)"
+         id="path557" />
+      <path
+         d="m 0,0 c 0,-0.146 -0.031,-0.293 -0.098,-0.432 -0.769,-1.607 -2.794,-1.468 -4.419,-1.357 -0.915,0.061 -2.3,0.157 -2.483,-0.228 -0.206,-0.393 0.753,-1.404 1.374,-2.082 1.103,-1.201 2.48,-2.696 1.709,-4.297 -0.772,-1.61 -2.796,-1.473 -4.423,-1.362 -0.915,0.061 -2.298,0.155 -2.484,-0.232 -0.207,-0.381 0.752,-1.402 1.375,-2.08 1.105,-1.201 2.478,-2.687 1.709,-4.299 -0.774,-1.609 -2.798,-1.475 -4.425,-1.365 -0.916,0.062 -2.301,0.154 -2.486,-0.233 -0.195,-0.394 0.754,-1.411 1.373,-2.087 1.101,-1.197 2.476,-2.695 1.707,-4.302 -0.239,-0.498 -0.836,-0.709 -1.334,-0.47 -0.5,0.238 -0.709,0.839 -0.471,1.333 0.217,0.404 -0.752,1.412 -1.373,2.088 -1.103,1.197 -2.481,2.683 -1.706,4.301 0.771,1.61 2.796,1.475 4.423,1.365 0.917,-0.062 2.302,-0.154 2.487,0.235 0.201,0.384 -0.753,1.406 -1.376,2.081 -1.101,1.199 -2.47,2.701 -1.707,4.3 0.771,1.607 2.796,1.47 4.423,1.359 0.916,-0.061 2.298,-0.154 2.483,0.233 0.196,0.376 -0.753,1.402 -1.374,2.077 -1.105,1.203 -2.476,2.705 -1.709,4.302 0.772,1.607 2.797,1.468 4.423,1.357 0.916,-0.063 2.296,-0.156 2.48,0.227 0.238,0.497 0.836,0.708 1.334,0.47 C -0.209,0.73 0,0.373 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1965.4728,-1.6414667)"
+         clip-path="url(#clipPath406)"
+         id="path558" />
+      <path
+         d="m 0,0 c 0,-0.068 -0.002,-0.135 -0.004,-0.203 -0.156,-4.2 -5.026,-5.94 -9.736,-7.622 -4.083,-1.458 -8.303,-2.966 -8.408,-5.811 -0.002,-0.035 -0.002,-0.072 -0.002,-0.107 0,-2.777 4.042,-4.567 7.955,-6.301 4.573,-2.023 9.328,-4.027 9.144,-8.313 -0.156,-4.192 -5.026,-5.928 -9.736,-7.606 -4.083,-1.456 -8.305,-2.96 -8.41,-5.799 -0.117,-2.933 3.991,-4.653 7.953,-6.407 4.574,-2.023 9.213,-4.057 9.145,-8.308 -0.156,-4.189 -5.027,-5.923 -9.736,-7.598 -4.081,-1.453 -8.303,-2.956 -8.407,-5.79 -0.021,-0.552 -0.484,-0.982 -1.036,-0.963 -0.551,0.024 -0.949,0.413 -0.963,1.037 0.156,4.189 5.026,5.923 9.736,7.598 4.081,1.453 8.303,2.957 8.406,5.79 0.094,2.804 -3.989,4.653 -7.953,6.406 -4.571,2.026 -9.264,4.078 -9.144,8.309 0.158,4.193 5.028,5.929 9.737,7.608 4.084,1.455 8.303,2.96 8.409,5.797 0.14,2.822 -3.992,4.656 -7.955,6.411 -4.57,2.025 -9.28,4.11 -9.143,8.311 0.156,4.198 5.026,5.938 9.734,7.619 4.083,1.459 8.305,2.966 8.41,5.813 0.055,2.919 -3.991,4.663 -7.953,6.42 -4.571,2.027 -9.207,4.054 -9.142,8.323 0.021,0.553 0.484,0.982 1.037,0.962 0.55,-0.021 0.939,-0.517 0.962,-1.037 -0.199,-2.819 3.993,-4.662 7.954,-6.42 C -4.649,6.125 0,4.063 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2466.9877,96.778533)"
+         clip-path="url(#clipPath407)"
+         id="path559" />
+      <path
+         d="m 0,0 c 0,-0.191 -0.054,-0.383 -0.166,-0.552 -0.306,-0.461 -0.925,-0.586 -1.386,-0.282 -3.062,2.031 -7.68,-1.162 -12.148,-4.251 -5.014,-3.468 -10.199,-7.053 -14.389,-4.274 -4.19,2.781 -2.904,8.953 -1.666,14.92 1.111,5.319 2.25,10.818 -0.81,12.843 -3.056,2.027 -7.672,-1.168 -12.136,-4.259 -5.01,-3.47 -10.193,-7.057 -14.38,-4.282 -4.188,2.775 -2.897,8.943 -1.65,14.911 1.11,5.317 2.258,10.81 -0.798,12.834 -3.054,2.028 -7.67,-1.169 -12.134,-4.26 -5.011,-3.47 -10.191,-7.057 -14.376,-4.284 -4.174,2.773 -2.886,8.941 -1.64,14.905 1.111,5.313 2.263,10.804 -0.789,12.829 -0.462,0.308 -0.58,0.931 -0.281,1.386 0.306,0.461 0.926,0.586 1.386,0.281 4.181,-2.771 2.888,-8.937 1.641,-14.905 -1.113,-5.315 -2.265,-10.806 0.789,-12.829 3.053,-2.024 7.67,1.17 12.132,4.261 5.012,3.47 10.193,7.059 14.377,4.284 4.185,-2.778 2.894,-8.947 1.65,-14.91 -1.111,-5.316 -2.255,-10.812 0.799,-12.836 3.056,-2.026 7.672,1.168 12.135,4.259 5.011,3.471 10.194,7.057 14.38,4.283 4.191,-2.781 2.908,-8.951 1.664,-14.919 -1.107,-5.315 -2.254,-10.818 0.812,-12.845 3.062,-2.03 7.68,1.162 12.148,4.252 5.014,3.468 10.199,7.053 14.389,4.274 C -0.156,0.641 0,0.322 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2187.346,1144.1319)"
+         clip-path="url(#clipPath408)"
+         id="path560" />
+      <path
+         d="m 0,0 c 0,-0.363 -0.199,-0.715 -0.545,-0.891 -3.592,-1.833 -7.316,1.432 -10.917,4.587 -3.101,2.718 -6.307,5.528 -8.691,4.312 -2.389,-1.219 -1.998,-5.469 -1.615,-9.568 0.439,-4.765 0.9,-9.699 -2.699,-11.537 -3.595,-1.835 -7.32,1.428 -10.923,4.583 -3.103,2.717 -6.311,5.526 -8.699,4.308 -2.392,-1.219 -2.002,-5.471 -1.617,-9.57 0.441,-4.767 0.894,-9.701 -2.701,-11.539 -3.601,-1.837 -7.33,1.424 -10.935,4.577 -3.104,2.717 -6.314,5.525 -8.709,4.302 -2.394,-1.222 -2.005,-5.465 -1.628,-9.576 0.441,-4.768 0.892,-9.701 -2.708,-11.54 -0.493,-0.252 -1.094,-0.057 -1.346,0.435 -0.246,0.493 -0.056,1.098 0.435,1.346 2.394,1.222 2.004,5.471 1.627,9.576 -0.433,4.776 -0.892,9.705 2.71,11.54 3.601,1.837 7.331,-1.423 10.935,-4.577 3.105,-2.716 6.315,-5.524 8.709,-4.302 2.392,1.221 2.002,5.472 1.619,9.574 -0.441,4.767 -0.894,9.699 2.699,11.535 3.597,1.835 7.322,-1.428 10.925,-4.585 3.103,-2.716 6.309,-5.524 8.697,-4.306 2.39,1.219 1.998,5.466 1.617,9.572 -0.436,4.77 -0.894,9.699 2.696,11.533 3.594,1.833 7.317,-1.432 10.918,-4.587 3.101,-2.718 6.307,-5.528 8.692,-4.312 0.491,0.252 1.095,0.057 1.345,-0.435 C -0.035,0.308 0,0.154 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2129.7421,333.4612)"
+         clip-path="url(#clipPath409)"
+         id="path561" />
+      <path
+         d="m 0,0 c 0,-0.354 -0.19,-0.697 -0.521,-0.879 -1.489,-0.808 -2.945,0.403 -4.119,1.377 -0.554,0.461 -1.587,1.32 -1.884,1.158 -0.301,-0.162 -0.141,-1.498 -0.053,-2.213 0.182,-1.511 0.402,-3.395 -1.082,-4.206 -1.489,-0.81 -2.948,0.403 -4.122,1.375 -0.554,0.461 -1.587,1.318 -1.884,1.156 -0.297,-0.16 -0.141,-1.495 -0.055,-2.212 0.182,-1.519 0.403,-3.4 -1.081,-4.206 -1.491,-0.811 -2.951,0.4 -4.124,1.372 -0.557,0.461 -1.592,1.319 -1.891,1.155 -0.302,-0.161 -0.14,-1.498 -0.056,-2.215 0.179,-1.515 0.402,-3.398 -1.086,-4.208 -0.484,-0.263 -1.092,-0.084 -1.357,0.4 -0.264,0.489 -0.084,1.092 0.4,1.358 0.303,0.16 0.145,1.501 0.057,2.216 -0.182,1.501 -0.404,3.394 1.085,4.206 1.49,0.81 2.949,-0.401 4.123,-1.373 0.556,-0.461 1.591,-1.318 1.892,-1.154 0.3,0.162 0.14,1.496 0.052,2.21 -0.183,1.518 -0.402,3.4 1.084,4.209 1.488,0.81 2.947,-0.403 4.118,-1.375 0.557,-0.461 1.59,-1.318 1.889,-1.156 0.3,0.16 0.138,1.498 0.052,2.212 -0.177,1.51 -0.402,3.394 1.082,4.206 1.488,0.809 2.947,-0.404 4.12,-1.376 0.555,-0.461 1.588,-1.32 1.882,-1.158 0.487,0.264 1.092,0.084 1.358,-0.401 C -0.039,0.326 0,0.162 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2486.9155,1227.2376)"
+         clip-path="url(#clipPath410)"
+         id="path562" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.58 -0.371,-0.777 -3.511,-2.847 -8.418,-0.1 -13.163,2.556 -4.165,2.329 -8.471,4.741 -10.929,2.745 -2.464,-1.997 -1,-6.709 0.422,-11.263 1.615,-5.198 3.284,-10.568 -0.231,-13.417 -3.514,-2.85 -8.423,-0.105 -13.171,2.55 -4.165,2.33 -8.472,4.738 -10.936,2.74 -2.462,-1.997 -0.998,-6.709 0.42,-11.267 1.615,-5.196 3.286,-10.568 -0.233,-13.417 -3.518,-2.854 -8.431,-0.111 -13.18,2.541 -4.169,2.327 -8.481,4.733 -10.951,2.732 -2.466,-2.002 -1.004,-6.72 0.412,-11.277 1.615,-5.19 3.286,-10.564 -0.242,-13.423 -0.428,-0.347 -1.059,-0.281 -1.406,0.149 -0.35,0.421 -0.285,1.056 0.148,1.406 2.467,1.997 1.004,6.713 -0.41,11.276 -1.611,5.195 -3.276,10.568 0.238,13.423 3.523,2.855 8.434,0.111 13.185,-2.541 4.169,-2.327 8.478,-4.733 10.949,-2.731 2.462,1.997 0.997,6.711 -0.42,11.267 -1.617,5.196 -3.288,10.568 0.232,13.417 3.515,2.85 8.424,0.105 13.171,-2.551 4.165,-2.329 8.472,-4.737 10.937,-2.739 2.456,1.992 0.996,6.707 -0.422,11.267 -1.617,5.194 -3.288,10.56 0.229,13.413 3.51,2.847 8.418,0.101 13.165,-2.557 4.163,-2.329 8.468,-4.739 10.929,-2.745 0.427,0.348 1.058,0.281 1.406,-0.148 C -0.072,0.445 0,0.222 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2477.8807,388.9588)"
+         clip-path="url(#clipPath411)"
+         id="path563" />
+      <path
+         d="m 0,0 c 0,-0.176 -0.045,-0.353 -0.143,-0.513 -2.65,-4.417 -9.05,-3.375 -15.24,-2.367 -5.532,0.9 -11.254,1.829 -13.206,-1.422 -1.959,-3.259 1.556,-7.871 4.954,-12.331 3.798,-4.989 7.73,-10.154 5.077,-14.571 -2.654,-4.421 -9.055,-3.382 -15.247,-2.376 -5.534,0.896 -11.257,1.826 -13.212,-1.432 -1.952,-3.272 1.555,-7.873 4.952,-12.335 3.798,-4.989 7.733,-10.151 5.075,-14.572 -2.655,-4.427 -9.06,-3.392 -15.254,-2.392 -5.536,0.894 -11.261,1.819 -13.22,-1.445 -1.948,-3.263 1.549,-7.881 4.945,-12.347 3.798,-4.995 7.728,-10.168 5.067,-14.584 -0.283,-0.475 -0.899,-0.63 -1.371,-0.344 -0.473,0.287 -0.629,0.906 -0.344,1.371 1.961,3.27 -1.55,7.882 -4.944,12.346 -3.798,4.991 -7.733,10.16 -5.067,14.585 2.656,4.426 9.059,3.392 15.252,2.392 5.538,-0.894 11.261,-1.82 13.222,1.445 1.947,3.263 -1.556,7.873 -4.952,12.335 -3.8,4.989 -7.733,10.154 -5.075,14.573 2.654,4.42 9.054,3.382 15.246,2.376 5.534,-0.896 11.258,-1.826 13.212,1.431 1.949,3.252 -1.56,7.872 -4.954,12.332 -3.799,4.989 -7.734,10.146 -5.077,14.571 2.65,4.416 9.051,3.374 15.241,2.366 5.532,-0.9 11.253,-1.83 13.206,1.421 0.285,0.475 0.898,0.629 1.371,0.344 C -0.174,0.67 0,0.338 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2400.4927,760.41013)"
+         clip-path="url(#clipPath412)"
+         id="path564" />
+      <path
+         d="m 0,0 c 0,-0.039 -0.002,-0.08 -0.008,-0.119 -0.183,-1.556 -1.831,-1.998 -3.157,-2.351 -0.506,-0.135 -1.56,-0.418 -1.689,-0.658 0.07,-0.258 1.029,-0.779 1.49,-1.029 1.204,-0.652 2.724,-1.457 2.519,-3.027 -0.184,-1.554 -1.83,-1.995 -3.154,-2.351 -0.508,-0.134 -1.562,-0.418 -1.691,-0.658 0.07,-0.259 1.029,-0.781 1.49,-1.031 1.205,-0.652 2.73,-1.457 2.519,-3.024 -0.184,-1.559 -1.832,-2.002 -3.158,-2.357 -0.505,-0.137 -1.562,-0.422 -1.689,-0.662 0.067,-0.262 1.028,-0.785 1.49,-1.035 1.205,-0.656 2.717,-1.471 2.519,-3.029 -0.064,-0.549 -0.56,-0.941 -1.109,-0.875 -0.547,0.063 -0.969,0.575 -0.875,1.109 -0.066,0.264 -1.029,0.785 -1.49,1.037 -1.206,0.656 -2.729,1.441 -2.519,3.031 0.184,1.554 1.832,1.998 3.156,2.353 0.507,0.137 1.564,0.422 1.691,0.662 -0.07,0.262 -1.029,0.783 -1.49,1.033 -1.205,0.654 -2.72,1.47 -2.519,3.026 0.184,1.555 1.832,1.998 3.156,2.354 0.507,0.134 1.56,0.417 1.689,0.657 -0.07,0.258 -1.029,0.78 -1.49,1.029 -1.203,0.653 -2.732,1.448 -2.519,3.025 0.184,1.556 1.832,1.998 3.157,2.351 0.506,0.135 1.561,0.418 1.689,0.658 0.067,0.549 0.563,0.938 1.111,0.873 C -0.373,0.931 0,0.5 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2073.794,1180.3449)"
+         clip-path="url(#clipPath413)"
+         id="path565" />
+      <path
+         d="m 0,0 c 0,-1.088 -0.279,-2.134 -0.931,-3.127 -2.617,-3.973 -8.43,-2.784 -14.052,-1.633 -4.969,1.016 -10.107,2.067 -11.978,-0.776 -1.868,-2.845 1.133,-7.139 4.033,-11.296 3.281,-4.702 6.676,-9.568 4.062,-13.542 -2.613,-3.968 -8.423,-2.775 -14.042,-1.621 -4.968,1.02 -10.103,2.074 -11.97,-0.763 -1.875,-2.833 1.132,-7.135 4.034,-11.293 3.283,-4.705 6.672,-9.571 4.064,-13.539 -2.611,-3.962 -8.418,-2.767 -14.036,-1.611 -4.966,1.021 -10.102,2.077 -11.964,-0.754 -0.305,-0.463 -0.924,-0.59 -1.385,-0.287 -0.465,0.307 -0.589,0.929 -0.287,1.384 2.611,3.966 8.42,2.771 14.038,1.615 4.966,-1.021 10.099,-2.077 11.962,0.754 1.867,2.827 -1.131,7.135 -4.032,11.294 -3.283,4.702 -6.676,9.574 -4.066,13.536 2.613,3.97 8.424,2.777 14.044,1.623 4.965,-1.019 10.103,-2.074 11.968,0.762 1.873,2.844 -1.131,7.138 -4.03,11.3 -3.281,4.703 -6.673,9.57 -4.064,13.537 2.617,3.976 8.43,2.785 14.05,1.635 4.969,-1.016 10.109,-2.068 11.979,0.775 1.869,2.845 -1.125,7.149 -4.024,11.31 -3.279,4.71 -6.663,9.582 -4.054,13.551 0.305,0.461 0.924,0.588 1.386,0.285 0.459,-0.308 0.586,-0.925 0.285,-1.386 -1.868,-2.841 1.125,-7.145 4.025,-11.308 C -2.525,6.891 0,3.267 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1504.5943,533.1028)"
+         clip-path="url(#clipPath414)"
+         id="path566" />
+      <path
+         d="m 0,0 c 0,-0.017 0,-0.035 -0.002,-0.054 -0.104,-1.904 -2.117,-2.582 -3.894,-3.178 -1.056,-0.355 -2.503,-0.841 -2.534,-1.392 -0.024,-0.482 1.355,-1.195 2.367,-1.663 1.7,-0.789 3.674,-1.764 3.522,-3.588 -0.105,-1.905 -2.119,-2.583 -3.894,-3.18 -1.056,-0.356 -2.503,-0.844 -2.534,-1.396 -0.039,-0.637 1.353,-1.194 2.366,-1.664 1.697,-0.789 3.638,-1.632 3.521,-3.589 -0.103,-1.906 -2.116,-2.586 -3.892,-3.185 -1.056,-0.356 -2.505,-0.846 -2.536,-1.4 -0.055,-0.572 1.355,-1.199 2.367,-1.67 1.699,-0.79 3.637,-1.595 3.52,-3.591 -0.029,-0.55 -0.502,-0.974 -1.052,-0.943 -0.551,0.03 -0.971,0.449 -0.943,1.053 -0.051,0.497 -1.358,1.199 -2.367,1.669 -1.699,0.789 -3.704,1.608 -3.521,3.591 0.104,1.908 2.117,2.587 3.894,3.187 1.056,0.355 2.503,0.844 2.535,1.398 -0.05,0.625 -1.356,1.195 -2.369,1.666 -1.699,0.787 -3.691,1.636 -3.519,3.587 0.104,1.906 2.117,2.583 3.892,3.181 1.058,0.357 2.505,0.843 2.536,1.396 v 0.019 c 0,0.547 -1.367,1.18 -2.366,1.645 -1.699,0.786 -3.693,1.605 -3.523,3.586 0.103,1.904 2.117,2.582 3.894,3.178 1.056,0.355 2.503,0.841 2.534,1.392 0.03,0.55 0.502,0.974 1.053,0.943 C -0.412,0.969 0,0.527 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2427.9264,836.29133)"
+         clip-path="url(#clipPath415)"
+         id="path567" />
+      <path
+         d="m 0,0 c 0,-0.484 -0.06,-0.978 -0.186,-1.484 -1.247,-5.042 -7.715,-5.938 -13.969,-6.805 -5.594,-0.775 -11.38,-1.576 -12.302,-5.301 -0.904,-3.703 3.822,-7.122 8.412,-10.416 5.13,-3.679 10.432,-7.463 9.188,-12.519 -1.246,-5.034 -7.713,-5.926 -13.966,-6.787 -5.592,-0.771 -11.376,-1.568 -12.296,-5.286 -0.913,-3.722 3.823,-7.122 8.412,-10.412 5.13,-3.68 10.434,-7.486 9.19,-12.516 -1.244,-5.028 -7.712,-5.917 -13.964,-6.776 -5.594,-0.769 -11.376,-1.564 -12.296,-5.276 -0.133,-0.537 -0.676,-0.863 -1.211,-0.731 -0.535,0.133 -0.867,0.676 -0.73,1.211 1.244,5.028 7.711,5.917 13.964,6.776 5.594,0.769 11.376,1.564 12.296,5.276 0.929,3.739 -3.825,7.122 -8.414,10.412 -5.13,3.68 -10.428,7.51 -9.188,12.516 1.246,5.032 7.712,5.925 13.964,6.786 5.595,0.771 11.378,1.57 12.298,5.288 0.912,3.729 -3.827,7.123 -8.41,10.414 -5.132,3.68 -10.44,7.48 -9.19,12.52 1.248,5.04 7.714,5.936 13.968,6.803 5.596,0.775 11.382,1.576 12.304,5.304 0.916,3.708 -3.822,7.132 -8.409,10.429 -5.131,3.683 -10.437,7.492 -9.183,12.532 0.133,0.535 0.674,0.863 1.211,0.73 0.533,-0.132 0.859,-0.665 0.73,-1.211 -0.925,-3.713 3.821,-7.134 8.408,-10.427 C -4.754,7.737 -0.002,4.321 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1549.7869,1293.7172)"
+         clip-path="url(#clipPath416)"
+         id="path568" />
+      <path
+         d="m 0,0 c 0,-0.02 0,-0.041 -0.002,-0.062 -0.035,-0.553 -0.509,-0.971 -1.06,-0.936 -4.339,0.276 -7.143,-5.629 -9.854,-11.341 -2.997,-6.311 -6.098,-12.837 -11.786,-12.477 -5.69,0.359 -7.943,7.222 -10.124,13.862 -1.971,6.006 -4.009,12.215 -8.348,12.491 -4.329,0.273 -7.129,-5.632 -9.837,-11.343 -2.994,-6.311 -6.089,-12.839 -11.771,-12.48 -5.683,0.359 -7.93,7.223 -10.106,13.862 -1.966,6.007 -4,12.216 -8.328,12.489 -4.329,0.274 -7.129,-5.631 -9.835,-11.343 -2.992,-6.31 -6.087,-12.838 -11.765,-12.479 -5.677,0.359 -7.922,7.223 -10.094,13.862 -1.964,6.005 -3.995,12.214 -8.316,12.487 -0.551,0.034 -1.011,0.451 -0.935,1.061 0.035,0.55 0.509,0.97 1.06,0.935 5.676,-0.358 7.922,-7.223 10.093,-13.862 1.965,-6.005 3.995,-12.214 8.317,-12.488 4.327,-0.273 7.127,5.632 9.834,11.341 2.991,6.314 6.086,12.842 11.766,12.482 5.683,-0.359 7.93,-7.223 10.105,-13.862 1.967,-6.006 4.001,-12.216 8.329,-12.489 4.331,-0.274 7.131,5.631 9.837,11.341 2.993,6.313 6.091,12.839 11.771,12.481 5.69,-0.359 7.943,-7.224 10.122,-13.864 1.973,-6.004 4.012,-12.216 8.35,-12.489 4.339,-0.275 7.143,5.63 9.856,11.341 2.995,6.311 6.096,12.837 11.784,12.478 C -0.406,0.965 0,0.523 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2053.2051,990.00573)"
+         clip-path="url(#clipPath417)"
+         id="path569" />
+      <path
+         d="m 0,0 v -0.039 c -0.07,-1.775 -1.976,-2.448 -3.509,-2.991 -0.861,-0.305 -2.162,-0.764 -2.177,-1.186 0.074,-0.435 1.241,-0.982 2.075,-1.355 1.484,-0.664 3.314,-1.521 3.263,-3.261 -0.07,-1.779 -1.978,-2.452 -3.511,-2.995 -0.859,-0.305 -2.159,-0.764 -2.175,-1.186 v -0.007 c 0,-0.424 1.248,-0.98 2.076,-1.349 1.457,-0.651 3.265,-1.457 3.265,-3.168 0,-0.031 -0.002,-0.062 -0.002,-0.095 -0.072,-1.78 -1.978,-2.455 -3.509,-2.998 -0.861,-0.304 -2.164,-0.767 -2.179,-1.191 0.013,-0.343 1.241,-0.988 2.077,-1.363 1.457,-0.648 3.263,-1.455 3.263,-3.165 0,-0.033 -0.002,-0.065 -0.002,-0.098 -0.023,-0.552 -0.488,-0.982 -1.038,-0.961 -0.553,0.022 -0.92,0.496 -0.961,1.039 v 0.01 c 0,0.424 -1.248,0.98 -2.076,1.349 -1.486,0.662 -3.255,1.484 -3.263,3.267 0.072,1.779 1.978,2.455 3.509,2.997 0.861,0.305 2.163,0.768 2.179,1.192 -0.016,0.402 -1.24,0.984 -2.077,1.357 -1.485,0.664 -3.295,1.492 -3.261,3.263 0.07,1.777 1.976,2.45 3.508,2.993 0.861,0.305 2.162,0.764 2.178,1.187 v 0.008 c 0,0.422 -1.248,0.979 -2.076,1.347 -1.486,0.665 -3.251,1.537 -3.263,3.262 0.072,1.776 1.978,2.45 3.511,2.993 0.859,0.303 2.16,0.763 2.175,1.183 C -1.978,0.592 -1.514,1.021 -0.961,1 -0.422,0.979 0,0.535 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1465.1323,838.02267)"
+         clip-path="url(#clipPath418)"
+         id="path570" />
+      <path
+         d="m 0,0 c 0,-0.119 -0.022,-0.24 -0.066,-0.358 -0.198,-0.515 -0.775,-0.773 -1.291,-0.575 -2.775,1.064 -2.82,4.557 -2.864,7.935 -0.036,2.713 -0.071,5.518 -1.581,6.097 -1.511,0.579 -3.415,-1.483 -5.254,-3.474 -2.295,-2.484 -4.665,-5.05 -7.442,-3.986 -2.776,1.064 -2.825,4.56 -2.87,7.94 -0.037,2.712 -0.074,5.518 -1.586,6.098 -1.511,0.58 -3.415,-1.482 -5.256,-3.474 -2.295,-2.484 -4.667,-5.05 -7.444,-3.985 -2.78,1.066 -2.829,4.561 -2.878,7.939 -0.037,2.715 -0.076,5.522 -1.594,6.105 -1.517,0.581 -3.422,-1.479 -5.266,-3.472 -2.294,-2.48 -4.669,-5.046 -7.447,-3.98 -0.516,0.197 -0.77,0.781 -0.576,1.291 0.197,0.515 0.775,0.773 1.29,0.576 1.517,-0.582 3.423,1.478 5.266,3.471 2.295,2.481 4.669,5.046 7.448,3.98 2.783,-1.066 2.831,-4.561 2.879,-7.941 0.038,-2.715 0.078,-5.521 1.593,-6.103 1.513,-0.58 3.417,1.482 5.26,3.476 2.293,2.482 4.663,5.048 7.44,3.984 2.777,-1.064 2.825,-4.56 2.871,-7.94 0.036,-2.712 0.074,-5.518 1.585,-6.098 1.512,-0.58 3.417,1.482 5.259,3.476 2.292,2.482 4.663,5.047 7.437,3.983 2.777,-1.064 2.822,-4.557 2.865,-7.937 C -2.187,4.315 -2.15,1.511 -0.642,0.933 -0.244,0.781 0,0.402 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1951.0073,531.21)"
+         clip-path="url(#clipPath419)"
+         id="path571" />
+      <path
+         d="m 0,0 c 0,-0.129 -0.025,-0.26 -0.078,-0.385 -0.213,-0.509 -0.797,-0.75 -1.307,-0.537 l -53.559,22.374 13.838,-33.695 c 0.145,-0.369 0.069,-0.803 -0.221,-1.088 -0.286,-0.285 -0.716,-0.369 -1.089,-0.213 l -50.68,21.173 c -0.511,0.213 -0.753,0.801 -0.536,1.307 0.212,0.509 0.796,0.749 1.306,0.537 l 48.453,-20.242 -13.838,33.695 c -0.151,0.361 -0.067,0.803 0.221,1.088 0.286,0.285 0.716,0.369 1.089,0.213 L -0.615,0.922 C -0.23,0.761 0,0.391 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2549.2889,294.51707)"
+         clip-path="url(#clipPath420)"
+         id="path572" />
+      <path
+         d="m 0,0 c 0,-0.525 -0.41,-0.967 -0.941,-0.998 l -47.025,-2.79 24.379,-21.648 c 0.299,-0.269 0.414,-0.697 0.282,-1.076 -0.133,-0.38 -0.483,-0.646 -0.887,-0.669 l -54.415,-3.228 c -0.551,-0.033 -1.023,0.386 -1.056,0.939 -0.077,0.529 0.388,1.023 0.939,1.057 l 52.005,3.085 -24.379,21.647 c -0.302,0.269 -0.418,0.687 -0.281,1.076 0.133,0.381 0.482,0.646 0.887,0.67 L -1.059,0.998 C -0.508,1.031 -0.035,0.611 -0.002,0.058 0,0.039 0,0.019 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2451.3456,651.09387)"
+         clip-path="url(#clipPath421)"
+         id="path573" />
+      <path
+         d="m 0,0 c 0,-0.305 -0.14,-0.608 -0.404,-0.803 l -35.562,-26.365 30.265,-4.495 c 0.4,-0.058 0.724,-0.353 0.823,-0.746 0.096,-0.394 -0.052,-0.804 -0.374,-1.044 l -41.28,-30.605 c -0.443,-0.33 -1.07,-0.236 -1.398,0.207 -0.326,0.446 -0.234,1.072 0.207,1.398 l 39.34,29.167 -30.264,4.496 c -0.4,0.058 -0.725,0.353 -0.824,0.746 -0.098,0.392 0.049,0.804 0.375,1.044 L -1.595,0.803 c 0.443,0.329 1.07,0.236 1.398,-0.208 C -0.064,0.416 0,0.207 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1722.0988,1092.4637)"
+         clip-path="url(#clipPath422)"
+         id="path574" />
+      <path
+         d="m 0,0 c 0,-0.131 -0.025,-0.262 -0.078,-0.389 -0.217,-0.509 -0.803,-0.748 -1.311,-0.533 l -30.508,12.904 7.672,-18.92 c 0.152,-0.373 0.064,-0.802 -0.225,-1.087 -0.286,-0.284 -0.718,-0.366 -1.089,-0.21 L -55.276,4.343 c -0.51,0.216 -0.742,0.806 -0.534,1.31 0.217,0.51 0.803,0.748 1.311,0.533 l 27.515,-11.638 -7.672,18.92 c -0.152,0.373 -0.064,0.802 0.225,1.087 0.286,0.284 0.718,0.366 1.089,0.209 L -0.611,0.922 C -0.228,0.76 0,0.389 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2406.1475,554.99387)"
+         clip-path="url(#clipPath423)"
+         id="path575" />
+      <path
+         d="m 0,0 c 0,-0.353 -0.189,-0.697 -0.523,-0.879 l -24.332,-13.202 18.089,-5.364 c 0.387,-0.115 0.668,-0.452 0.709,-0.855 0.045,-0.4 -0.162,-0.789 -0.517,-0.982 l -29.119,-15.797 c -0.484,-0.264 -1.091,-0.084 -1.355,0.402 -0.262,0.477 -0.086,1.088 0.402,1.355 l 26.996,14.647 -18.09,5.364 c -0.386,0.115 -0.667,0.453 -0.708,0.856 -0.049,0.394 0.162,0.789 0.517,0.982 L -1.476,0.879 C -0.992,1.143 -0.385,0.963 -0.121,0.477 -0.039,0.326 0,0.162 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1542.3407,927.24693)"
+         clip-path="url(#clipPath424)"
+         id="path576" />
+      <path
+         d="m 0,0 c 0,-0.211 -0.066,-0.422 -0.203,-0.603 -0.332,-0.44 -0.959,-0.528 -1.4,-0.194 l -21.718,16.424 2.548,-18.37 c 0.055,-0.389 -0.136,-0.795 -0.484,-1 -0.349,-0.203 -0.787,-0.178 -1.109,0.066 l -26.021,19.683 c -0.442,0.332 -0.528,0.955 -0.194,1.4 0.332,0.44 0.959,0.527 1.4,0.194 l 24.096,-18.227 -2.548,18.371 c -0.049,0.391 0.137,0.797 0.484,1 0.35,0.203 0.787,0.177 1.11,-0.067 L -0.396,0.797 C -0.137,0.601 0,0.303 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1780.5649,365.6336)"
+         clip-path="url(#clipPath425)"
+         id="path577" />
+      <path
+         d="m 0,0 c 0,-0.254 -0.098,-0.51 -0.291,-0.705 l -7.795,-7.846 6.241,0.02 c 0.404,0.002 0.771,-0.243 0.925,-0.615 0.157,-0.371 0.071,-0.801 -0.213,-1.09 l -8.626,-8.684 c -0.389,-0.39 -1.022,-0.394 -1.414,-0.004 -0.393,0.387 -0.393,1.02 -0.004,1.414 l 6.926,6.971 -6.241,-0.019 c -0.404,-0.002 -0.771,0.24 -0.925,0.615 -0.16,0.367 -0.074,0.8 0.212,1.089 l 9.496,9.559 c 0.389,0.39 1.022,0.394 1.414,0.004 C -0.098,0.513 0,0.258 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2409.152,1133.1861)"
+         clip-path="url(#clipPath426)"
+         id="path578" />
+      <path
+         d="m 0,0 c 0,-0.255 -0.098,-0.513 -0.295,-0.709 l -33.371,-33.24 32.6,-0.064 c 0.404,0 0.769,-0.247 0.922,-0.619 0.154,-0.371 0.07,-0.803 -0.219,-1.09 l -38.614,-38.466 c -0.391,-0.388 -1.024,-0.388 -1.414,0.004 -0.387,0.391 -0.391,1.023 0.004,1.414 l 36.903,36.761 -32.6,0.064 c -0.404,0 -0.769,0.246 -0.921,0.619 -0.148,0.375 -0.068,0.803 0.219,1.09 L -1.705,0.709 C -1.314,1.098 -0.681,1.098 -0.291,0.705 -0.098,0.51 0,0.256 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2533.5687,1062.4605)"
+         clip-path="url(#clipPath427)"
+         id="path579" />
+      <path
+         d="m 0,0 c 0,-0.291 -0.127,-0.578 -0.369,-0.777 -0.43,-0.348 -1.061,-0.281 -1.408,0.146 l -29.247,36.06 -3.003,-28.805 c -0.042,-0.403 -0.323,-0.741 -0.709,-0.856 -0.389,-0.115 -0.807,0.016 -1.063,0.328 l -27.952,34.461 c -0.348,0.426 -0.283,1.055 0.146,1.408 0.43,0.348 1.058,0.281 1.408,-0.146 l 26.432,-32.587 3.003,28.806 c 0.041,0.402 0.322,0.74 0.709,0.855 0.388,0.116 0.806,-0.015 1.062,-0.327 L -0.223,0.631 C -0.072,0.445 0,0.223 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2049.1517,224.73907)"
+         clip-path="url(#clipPath428)"
+         id="path580" />
+      <path
+         d="m 0,0 c 0,-0.539 -0.429,-0.984 -0.973,-1 l -27.253,-0.769 12.103,-11.437 c 0.295,-0.275 0.394,-0.703 0.246,-1.082 -0.143,-0.379 -0.502,-0.632 -0.906,-0.644 l -26.951,-0.762 c -0.551,-0.015 -1.012,0.42 -1.027,0.973 -0.008,0.49 0.42,1.011 0.972,1.027 l 24.538,0.693 -12.103,11.437 c -0.291,0.277 -0.389,0.707 -0.246,1.082 0.142,0.378 0.502,0.632 0.906,0.644 L -1.027,1 C -0.477,1.015 -0.016,0.58 0,0.028 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1788.4068,175.61747)"
+         clip-path="url(#clipPath429)"
+         id="path581" />
+      <path
+         d="m 0,0 c 0,-0.057 -0.004,-0.114 -0.014,-0.172 -0.093,-0.545 -0.611,-0.91 -1.156,-0.816 l -15.397,2.652 5.966,-8.448 c 0.238,-0.326 0.246,-0.767 0.029,-1.109 -0.216,-0.341 -0.617,-0.521 -1.015,-0.453 l -19.564,3.366 c -0.545,0.094 -0.916,0.608 -0.816,1.156 0.094,0.545 0.611,0.911 1.156,0.817 l 17.185,-2.958 -5.965,8.447 c -0.234,0.332 -0.244,0.771 -0.029,1.109 0.216,0.342 0.617,0.521 1.015,0.453 L -0.83,0.984 C -0.344,0.9 0,0.476 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1342.2151,403.9736)"
+         clip-path="url(#clipPath430)"
+         id="path582" />
+      <path
+         d="m 0,0 c 0,-0.135 -0.027,-0.272 -0.084,-0.4 l -5.7,-13.075 c -0.22,-0.506 -0.808,-0.737 -1.316,-0.516 -0.505,0.223 -0.73,0.818 -0.515,1.316 l 4.735,10.861 -6.284,-2.468 c -0.377,-0.147 -0.805,-0.053 -1.086,0.238 -0.277,0.291 -0.357,0.721 -0.195,1.093 L -5.266,8.93 c 0.22,0.505 0.808,0.736 1.316,0.515 0.508,-0.219 0.736,-0.81 0.515,-1.316 l -4.214,-9.666 6.284,2.468 C -0.988,1.078 -0.56,0.984 -0.279,0.693 -0.098,0.504 0,0.254 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1404.888,337.62187)"
+         clip-path="url(#clipPath431)"
+         id="path583" />
+      <path
+         d="m 0,0 c 0,-0.525 -0.41,-0.967 -0.941,-0.998 -0.551,-0.033 -1.023,0.387 -1.057,0.939 L -4.847,47.932 -24.78,25.482 c -0.269,-0.302 -0.693,-0.414 -1.076,-0.281 -0.38,0.133 -0.646,0.482 -0.67,0.887 l -2.715,45.788 c -0.044,0.568 0.388,1.023 0.939,1.056 0.55,0.034 1.023,-0.386 1.056,-0.939 l 2.574,-43.379 19.933,22.45 c 0.269,0.303 0.693,0.414 1.075,0.281 0.382,-0.132 0.647,-0.482 0.67,-0.886 L -0.002,0.058 C 0,0.039 0,0.019 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1600.6559,235.81173)"
+         clip-path="url(#clipPath432)"
+         id="path584" />
+      <path
+         d="m 0,0 c 0,-0.156 -0.037,-0.314 -0.111,-0.459 l -5.378,-10.415 c -0.254,-0.491 -0.857,-0.684 -1.347,-0.43 -0.49,0.254 -0.682,0.859 -0.43,1.347 l 4.271,8.272 -4.874,-1.556 c -0.387,-0.123 -0.807,-0.002 -1.069,0.308 -0.261,0.307 -0.31,0.746 -0.124,1.103 l 4.885,9.463 c 0.254,0.49 0.857,0.683 1.348,0.43 C -2.338,7.809 -2.15,7.202 -2.4,6.715 l -3.778,-7.318 4.873,1.556 C -0.918,1.076 -0.498,0.955 -0.236,0.645 -0.08,0.461 0,0.23 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2385.5767,227.116)"
+         clip-path="url(#clipPath433)"
+         id="path585" />
+      <path
+         d="m 0,0 c 0,-0.018 0,-0.033 -0.002,-0.051 l -0.793,-15.398 c -0.027,-0.553 -0.498,-0.977 -1.049,-0.948 -0.55,0.03 -1.019,0.467 -0.947,1.049 l 0.668,12.989 -6.305,-5.686 c -0.3,-0.271 -0.734,-0.334 -1.099,-0.16 -0.367,0.172 -0.619,0.556 -0.568,0.953 l 0.872,16.951 c 0.028,0.553 0.498,0.977 1.049,0.947 0.55,-0.027 1.021,-0.426 0.947,-1.049 L -7.975,-4.944 -1.67,0.742 c 0.301,0.272 0.735,0.334 1.1,0.16 C -0.221,0.736 0,0.385 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1940.3276,609.83027)"
+         clip-path="url(#clipPath434)"
+         id="path586" />
+      <path
+         d="m 0,0 c 0,-0.512 -0.392,-0.949 -0.912,-0.994 l -10.095,-0.89 4.952,-4.15 c 0.308,-0.258 0.43,-0.679 0.31,-1.066 -0.121,-0.385 -0.462,-0.66 -0.865,-0.695 L -20.368,-9.01 c -0.551,-0.049 -1.035,0.358 -1.084,0.908 -0.047,0.529 0.359,1.037 0.908,1.084 l 11.355,1.002 -4.952,4.149 c -0.311,0.256 -0.438,0.674 -0.311,1.066 0.121,0.385 0.463,0.66 0.865,0.695 L -1.088,0.998 C -0.537,1.047 -0.053,0.64 -0.004,0.09 -0.002,0.06 0,0.029 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1779.8253,1163.5099)"
+         clip-path="url(#clipPath435)"
+         id="path587" />
+      <path
+         d="m 0,0 c 0,-0.367 -0.203,-0.721 -0.554,-0.894 -0.495,-0.246 -1.094,-0.045 -1.34,0.449 l -18.578,37.282 -9.13,-27.259 c -0.127,-0.383 -0.475,-0.65 -0.877,-0.68 -0.404,-0.027 -0.785,0.19 -0.965,0.553 l -21.631,43.418 c -0.252,0.488 -0.046,1.093 0.449,1.339 0.494,0.246 1.093,0.045 1.339,-0.449 l 20.556,-41.256 9.131,27.259 c 0.126,0.383 0.474,0.651 0.876,0.68 0.405,0.027 0.785,-0.19 0.965,-0.553 L -0.105,0.445 C -0.033,0.303 0,0.15 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1676.5755,1307.7945)"
+         clip-path="url(#clipPath436)"
+         id="path588" />
+      <path
+         d="m 0,0 c 0,-0.515 -0.396,-0.953 -0.919,-0.994 l -11.822,-0.961 5.149,-4.376 c 0.307,-0.261 0.426,-0.677 0.303,-1.068 -0.123,-0.384 -0.467,-0.658 -0.871,-0.689 l -12.925,-1.049 c -0.548,-0.044 -1.031,0.366 -1.076,0.916 -0.021,0.535 0.365,1.033 0.916,1.076 l 10.519,0.854 -5.149,4.375 c -0.308,0.26 -0.432,0.676 -0.303,1.069 0.123,0.384 0.467,0.658 0.871,0.689 L -1.08,0.998 C -0.531,1.043 -0.049,0.633 -0.004,0.082 -0.002,0.055 0,0.027 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1335.7893,703.20187)"
+         clip-path="url(#clipPath437)"
+         id="path589" />
+      <path
+         d="m 0,0 c 0,-0.229 -0.078,-0.459 -0.238,-0.648 -0.357,-0.42 -0.988,-0.471 -1.41,-0.114 l -11.745,9.982 0.73,-9.009 c 0.029,-0.397 -0.18,-0.787 -0.539,-0.971 -0.361,-0.183 -0.797,-0.133 -1.105,0.129 l -12.341,10.49 c -0.42,0.357 -0.469,0.988 -0.113,1.41 0.357,0.42 0.988,0.47 1.41,0.113 l 10.501,-8.926 -0.73,9.01 c -0.028,0.386 0.179,0.787 0.539,0.97 0.361,0.184 0.796,0.133 1.105,-0.128 L -0.351,0.761 C -0.119,0.564 0,0.283 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1654.8305,651.6068)"
+         clip-path="url(#clipPath438)"
+         id="path590" />
+      <path
+         d="m 0,0 c 0,-0.434 -0.285,-0.834 -0.723,-0.961 l -14.555,-4.208 8.762,-4.833 c 0.355,-0.195 0.561,-0.58 0.511,-0.986 -0.044,-0.402 -0.328,-0.736 -0.716,-0.849 l -18.572,-5.37 c -0.529,-0.152 -1.084,0.153 -1.238,0.684 -0.158,0.517 0.154,1.083 0.683,1.237 l 16.253,4.7 -8.762,4.833 c -0.354,0.196 -0.555,0.582 -0.512,0.986 0.045,0.403 0.328,0.737 0.717,0.85 L -1.277,0.961 C -0.748,1.113 -0.193,0.809 -0.039,0.277 -0.012,0.186 0,0.092 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2154.9396,995.62427)"
+         clip-path="url(#clipPath439)"
+         id="path591" />
+      <path
+         d="m 0,0 c 0,-0.425 -0.273,-0.82 -0.701,-0.955 -0.527,-0.164 -1.087,0.129 -1.253,0.656 L -5.167,9.992 -7.983,4.622 C -8.17,4.265 -8.554,4.054 -8.957,4.091 -9.359,4.128 -9.701,4.403 -9.822,4.788 l -3.573,11.443 c -0.162,0.539 0.13,1.089 0.656,1.253 0.527,0.164 1.088,-0.128 1.254,-0.656 l 2.852,-9.138 2.814,5.37 c 0.189,0.357 0.574,0.568 0.976,0.531 0.403,-0.037 0.744,-0.313 0.865,-0.697 L -0.045,0.299 C -0.014,0.199 0,0.098 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2039.1615,111.52293)"
+         clip-path="url(#clipPath440)"
+         id="path592" />
+      <path
+         d="m 0,0 c 0,-0.188 -0.052,-0.377 -0.16,-0.543 l -8.529,-13.218 c -0.299,-0.463 -0.918,-0.597 -1.383,-0.297 -0.464,0.299 -0.597,0.922 -0.296,1.383 l 7.22,11.189 -7.519,-1.623 c -0.397,-0.084 -0.803,0.076 -1.033,0.41 -0.231,0.332 -0.237,0.771 -0.018,1.111 l 7.75,12.007 c 0.299,0.463 0.918,0.598 1.383,0.297 0.463,-0.301 0.599,-0.923 0.297,-1.383 l -6.44,-9.978 7.517,1.621 C -0.814,1.062 -0.408,0.902 -0.178,0.568 -0.058,0.398 0,0.199 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2174.7292,654.53573)"
+         clip-path="url(#clipPath441)"
+         id="path593" />
+      <path
+         d="m 0,0 c 0,-0.107 -0.018,-0.217 -0.053,-0.324 -0.179,-0.521 -0.748,-0.801 -1.271,-0.623 l -34.613,11.826 11.083,-22.583 c 0.178,-0.36 0.119,-0.797 -0.148,-1.101 -0.267,-0.305 -0.691,-0.416 -1.072,-0.288 L -66.688,0.779 c -0.525,0.18 -0.792,0.754 -0.625,1.27 0.18,0.523 0.748,0.802 1.27,0.624 l 38.331,-13.092 -11.084,22.583 c -0.173,0.363 -0.117,0.8 0.149,1.101 0.267,0.304 0.691,0.415 1.074,0.287 L -0.675,0.947 C -0.262,0.805 0,0.416 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2631.9211,366.33413)"
+         clip-path="url(#clipPath442)"
+         id="path594" />
+      <path
+         d="M 0,0 C 0,-0.092 -0.014,-0.188 -0.041,-0.281 -0.195,-0.81 -0.75,-1.115 -1.281,-0.959 L -26.603,6.44 -17.98,-9.301 c 0.193,-0.353 0.158,-0.792 -0.098,-1.107 -0.254,-0.314 -0.672,-0.447 -1.06,-0.332 l -30.425,8.887 c -0.529,0.152 -0.837,0.695 -0.677,1.24 0.154,0.529 0.709,0.834 1.24,0.677 l 28.106,-8.208 -8.622,15.74 c -0.194,0.355 -0.157,0.791 0.097,1.107 0.254,0.315 0.672,0.447 1.06,0.332 L -0.719,0.959 C -0.283,0.832 0,0.434 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2080.532,636.15493)"
+         clip-path="url(#clipPath443)"
+         id="path595" />
+      <path
+         d="m 0,0 c 0,-0.253 -0.096,-0.507 -0.287,-0.701 -0.389,-0.394 -1.021,-0.398 -1.414,-0.012 l -37.013,36.449 0.275,-36.023 v -0.008 c 0,-0.402 -0.24,-0.763 -0.609,-0.922 -0.373,-0.155 -0.804,-0.073 -1.091,0.21 l -42.633,41.984 c -0.395,0.387 -0.398,1.023 -0.012,1.414 0.389,0.394 1.022,0.398 1.414,0.012 l 40.915,-40.292 -0.276,36.023 v 0.008 c 0,0.402 0.24,0.764 0.609,0.921 0.373,0.157 0.805,0.075 1.092,-0.208 L -0.299,0.713 C -0.1,0.517 0,0.258 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2266.0575,953.4856)"
+         clip-path="url(#clipPath444)"
+         id="path596" />
+      <path
+         d="m 0,0 c 0,-0.521 -0.406,-0.961 -0.933,-0.996 -0.553,-0.035 -1.028,0.381 -1.065,0.932 L -2.578,8.754 -6.229,4.587 C -6.495,4.282 -6.918,4.169 -7.301,4.298 c -0.385,0.131 -0.65,0.478 -0.678,0.88 l -0.814,12.357 c -0.043,0.562 0.383,1.029 0.931,1.064 0.551,0.036 1.028,-0.38 1.065,-0.931 l 0.656,-9.949 3.651,4.167 c 0.266,0.304 0.69,0.418 1.072,0.289 0.385,-0.131 0.651,-0.478 0.678,-0.881 L -0.002,0.068 C 0,0.045 0,0.023 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1836.6016,577.69427)"
+         clip-path="url(#clipPath445)"
+         id="path597" />
+      <path
+         d="m 0,0 c 0,-0.422 -0.268,-0.812 -0.689,-0.951 l -23.184,-7.565 14.744,-7.49 c 0.36,-0.181 0.559,-0.535 0.543,-0.968 -0.031,-0.403 -0.3,-0.746 -0.685,-0.873 L -37.313,-27 c -0.526,-0.169 -1.09,0.116 -1.262,0.641 -0.17,0.527 0.113,1.088 0.64,1.261 l 25.749,8.403 -14.745,7.49 c -0.362,0.182 -0.608,0.547 -0.543,0.969 0.031,0.402 0.301,0.746 0.685,0.873 L -1.31,0.951 C -0.785,1.121 -0.22,0.836 -0.049,0.31 -0.016,0.207 0,0.104 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1355.5192,1227.5944)"
+         clip-path="url(#clipPath446)"
+         id="path598" />
+      <path
+         d="m 0,0 c 0,-0.215 -0.068,-0.43 -0.209,-0.613 -0.34,-0.436 -0.967,-0.516 -1.404,-0.178 l -42.326,32.819 4.212,-33.28 c 0.052,-0.404 -0.147,-0.794 -0.496,-0.993 -0.352,-0.2 -0.789,-0.17 -1.11,0.077 l -40.188,31.159 c -0.439,0.34 -0.513,0.965 -0.177,1.404 0.339,0.436 0.967,0.516 1.404,0.178 l 38.28,-29.681 -4.212,33.28 c -0.055,0.394 0.147,0.793 0.496,0.993 0.352,0.2 0.789,0.17 1.109,-0.077 L -0.387,0.791 C -0.133,0.593 0,0.297 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1743.5111,451.81173)"
+         clip-path="url(#clipPath447)"
+         id="path599" />
+      <path
+         d="M 0,0 C 0,-0.547 -0.439,-0.992 -0.986,-1 -1.539,-1.007 -1.992,-0.566 -2,-0.014 L -2.216,16.373 -9.809,8.578 c -0.283,-0.291 -0.71,-0.381 -1.087,-0.232 -0.375,0.15 -0.623,0.512 -0.629,0.916 l -0.271,20.694 v 0.014 c 0,0.547 0.439,0.992 0.986,1 0.552,0.007 1.005,-0.436 1.013,-0.986 l 0.24,-18.281 7.593,7.795 c 0.283,0.291 0.71,0.38 1.087,0.232 0.375,-0.151 0.623,-0.512 0.629,-0.916 L 0,0.014 Z"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1321.9179,940.82187)"
+         clip-path="url(#clipPath448)"
+         id="path600" />
+      <path
+         d="M 0,0 C 0,-0.112 -0.02,-0.225 -0.057,-0.334 L -19.796,-55.95 c -0.186,-0.521 -0.758,-0.793 -1.277,-0.609 -0.522,0.187 -0.793,0.763 -0.61,1.277 L -2.749,-1.941 -34.8,-17.199 c -0.366,-0.174 -0.799,-0.111 -1.1,0.16 -0.303,0.269 -0.406,0.689 -0.273,1.076 l 17.933,50.527 c 0.186,0.522 0.758,0.793 1.277,0.61 0.522,-0.186 0.797,-0.758 0.609,-1.278 L -33.481,-14.356 -1.429,0.902 C -1.064,1.076 -0.631,1.013 -0.33,0.742 -0.115,0.549 0,0.277 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1364.1449,574.26787)"
+         clip-path="url(#clipPath449)"
+         id="path601" />
+      <path
+         d="M 0,0 C 0,-0.43 -0.277,-0.824 -0.709,-0.957 L -23.928,-8.039 -9.4,-15.776 c 0.355,-0.189 0.556,-0.573 0.525,-0.978 -0.039,-0.404 -0.318,-0.742 -0.705,-0.861 l -28.099,-8.572 c -0.527,-0.16 -1.086,0.137 -1.248,0.666 -0.16,0.525 0.139,1.083 0.666,1.247 l 25.79,7.868 L -27,-8.67 c -0.355,0.192 -0.542,0.586 -0.525,0.979 0.039,0.404 0.318,0.741 0.705,0.861 L -1.291,0.957 C -0.763,1.117 -0.205,0.82 -0.043,0.291 -0.014,0.196 0,0.096 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1774.6285,95.261067)"
+         clip-path="url(#clipPath450)"
+         id="path602" />
+      <path
+         d="m 0,0 c 0,-0.457 -0.314,-0.869 -0.779,-0.975 l -50.488,-11.468 27.413,-17.265 c 0.342,-0.215 0.519,-0.611 0.453,-1.014 -0.068,-0.398 -0.371,-0.716 -0.765,-0.806 l -48.009,-10.906 c -0.537,-0.123 -1.074,0.215 -1.195,0.754 -0.137,0.537 0.215,1.072 0.754,1.195 l 45.653,10.371 -27.413,17.265 c -0.342,0.215 -0.52,0.613 -0.453,1.014 0.068,0.398 0.371,0.716 0.765,0.806 L -1.22,0.974 C -0.683,1.097 -0.146,0.759 -0.026,0.221 -0.008,0.146 0,0.072 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1719.4461,826.7228)"
+         clip-path="url(#clipPath451)"
+         id="path603" />
+      <path
+         d="m 0,0 c 0,-0.027 0,-0.053 -0.004,-0.08 -0.043,-0.551 -0.523,-0.961 -1.074,-0.918 l -15.545,1.211 5.95,-6.955 c 0.263,-0.305 0.32,-0.741 0.131,-1.104 -0.184,-0.361 -0.565,-0.576 -0.969,-0.542 l -16.311,1.27 c -0.55,0.042 -0.947,0.544 -0.917,1.075 0.043,0.55 0.523,0.96 1.074,0.917 l 13.903,-1.083 -5.95,6.957 c -0.26,0.307 -0.317,0.746 -0.131,1.103 0.184,0.361 0.564,0.576 0.969,0.543 l 17.953,-1.4 C -0.398,0.955 0,0.515 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1817.1004,871.3664)"
+         clip-path="url(#clipPath452)"
+         id="path604" />
+      <path
+         d="M 0,0 C 0,-0.178 -0.047,-0.355 -0.144,-0.518 -0.429,-0.99 -1.045,-1.14 -1.517,-0.855 l -22.938,13.858 3.917,-15.877 c 0.098,-0.396 -0.051,-0.805 -0.377,-1.045 -0.326,-0.24 -0.766,-0.26 -1.111,-0.05 L -44.742,9.756 c -0.472,0.288 -0.619,0.904 -0.338,1.372 0.286,0.473 0.901,0.623 1.373,0.338 l 20.65,-12.477 -3.917,15.877 c -0.1,0.387 0.049,0.802 0.377,1.044 0.326,0.241 0.765,0.26 1.11,0.051 L -0.482,0.855 C -0.172,0.668 0,0.338 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1630.5524,571.06053)"
+         clip-path="url(#clipPath453)"
+         id="path605" />
+      <path
+         d="m 0,0 c 0,-0.221 -0.072,-0.439 -0.215,-0.619 l -7.277,-9.224 c -0.342,-0.434 -0.971,-0.508 -1.404,-0.166 -0.432,0.343 -0.506,0.972 -0.166,1.404 l 5.782,7.33 -5.099,-0.601 c -0.402,-0.049 -0.793,0.15 -0.99,0.503 -0.195,0.352 -0.162,0.791 0.088,1.107 l 6.612,8.381 c 0.342,0.434 0.97,0.508 1.404,0.166 0.435,-0.339 0.507,-0.968 0.166,-1.404 l -5.116,-6.486 5.098,0.601 c 0.402,0.049 0.793,-0.15 0.99,-0.504 C -0.043,0.336 0,0.168 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1619.9767,963.65507)"
+         clip-path="url(#clipPath454)"
+         id="path606" />
+      <path
+         d="m 0,0 c 0,-0.016 0,-0.029 -0.002,-0.045 -0.024,-0.552 -0.492,-0.978 -1.043,-0.953 l -46.28,2.115 21.606,-23.676 c 0.274,-0.299 0.336,-0.732 0.168,-1.098 -0.172,-0.367 -0.549,-0.593 -0.951,-0.574 l -53.595,2.453 c -0.553,0.023 -1.01,0.488 -0.953,1.042 0.023,0.553 0.492,0.979 1.043,0.953 l 51.185,-2.341 -21.606,23.676 c -0.274,0.301 -0.332,0.735 -0.168,1.098 0.172,0.367 0.549,0.593 0.951,0.574 L -0.955,0.998 C -0.418,0.975 0,0.531 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2202.8299,454.54813)"
+         clip-path="url(#clipPath455)"
+         id="path607" />
+      <path
+         d="m 0,0 c 0,-0.504 -0.379,-0.935 -0.892,-0.992 l -44.787,-4.881 24.284,-19.512 c 0.316,-0.251 0.451,-0.667 0.332,-1.06 -0.114,-0.387 -0.45,-0.67 -0.852,-0.713 l -51.939,-5.66 c -0.549,-0.061 -1.041,0.335 -1.101,0.886 -0.043,0.529 0.334,1.041 0.886,1.101 l 49.539,5.399 -24.283,19.512 c -0.314,0.255 -0.439,0.669 -0.332,1.06 0.114,0.387 0.449,0.67 0.852,0.713 L -1.107,0.996 C -0.558,1.057 -0.066,0.66 -0.005,0.11 -0.002,0.074 0,0.037 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2398.9249,930.55333)"
+         clip-path="url(#clipPath456)"
+         id="path608" />
+      <path
+         d="m 0,0 c 0,-0.42 -0.266,-0.811 -0.686,-0.949 l -30.168,-9.99 19.448,-9.773 c 0.362,-0.18 0.574,-0.545 0.549,-0.965 -0.029,-0.404 -0.299,-0.75 -0.684,-0.877 l -35.727,-11.829 c -0.526,-0.174 -1.09,0.111 -1.264,0.635 -0.182,0.517 0.114,1.089 0.635,1.263 l 33.438,11.072 -19.449,9.773 c -0.36,0.181 -0.575,0.557 -0.549,0.964 0.029,0.405 0.299,0.75 0.684,0.877 L -1.314,0.949 C -0.789,1.122 -0.225,0.837 -0.051,0.314 -0.016,0.211 0,0.103 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1881.5625,-1.6025333)"
+         clip-path="url(#clipPath457)"
+         id="path609" />
+      <path
+         d="m 0,0 c 0,-0.461 -0.318,-0.875 -0.787,-0.976 -0.539,-0.119 -1.072,0.222 -1.189,0.763 l -4.983,22.77 -8.512,-13.28 c -0.219,-0.341 -0.619,-0.515 -1.017,-0.445 -0.399,0.072 -0.715,0.375 -0.801,0.771 l -6.053,27.658 c -0.109,0.541 0.224,1.072 0.763,1.189 0.539,0.119 1.072,-0.222 1.189,-0.763 l 5.538,-25.299 8.512,13.28 c 0.219,0.342 0.619,0.518 1.017,0.445 0.399,-0.072 0.715,-0.375 0.801,-0.771 L -0.023,0.213 C -0.008,0.142 0,0.07 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1428.1223,964.14187)"
+         clip-path="url(#clipPath458)"
+         id="path610" />
+      <path
+         d="m 0,0 c 0,-0.496 -0.369,-0.925 -0.875,-0.99 -0.547,-0.068 -1.047,0.319 -1.117,0.867 L -9.505,59.282 -32.547,29.566 c -0.248,-0.319 -0.664,-0.457 -1.055,-0.352 -0.39,0.108 -0.677,0.438 -0.728,0.84 l -7.1,56.147 c -0.07,0.527 0.318,1.047 0.867,1.117 0.547,0.068 1.047,-0.318 1.117,-0.867 L -32.649,32.7 -9.607,62.415 c 0.248,0.319 0.664,0.457 1.054,0.352 0.391,-0.107 0.678,-0.437 0.729,-0.84 l 7.816,-61.8 C -0.002,0.084 0,0.043 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2222.924,396.9)"
+         clip-path="url(#clipPath459)"
+         id="path611" />
+      <path
+         d="M 0,0 C 0,-0.244 -0.088,-0.488 -0.268,-0.681 -0.643,-1.086 -1.275,-1.109 -1.681,-0.732 L -7.955,5.096 -7.783,0.461 C -7.743,0.076 -8,-0.318 -8.367,-0.486 -8.734,-0.654 -9.168,-0.584 -9.463,-0.309 l -7.309,6.79 c -0.406,0.379 -0.427,1.011 -0.053,1.412 0.376,0.406 1.008,0.429 1.413,0.052 l 5.541,-5.147 -0.172,4.638 c 0.02,0.418 0.217,0.779 0.584,0.947 0.367,0.168 0.801,0.098 1.096,-0.178 L -0.32,0.732 C -0.108,0.535 0,0.268 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2494.0259,589.67067)"
+         clip-path="url(#clipPath460)"
+         id="path612" />
+      <path
+         d="m 0,0 c 0,-0.072 -0.008,-0.144 -0.023,-0.217 l -2.728,-12.239 c -0.121,-0.539 -0.654,-0.879 -1.193,-0.76 -0.539,0.12 -0.877,0.652 -0.76,1.194 l 2.203,9.884 -4.761,-3.027 c -0.342,-0.217 -0.781,-0.207 -1.111,0.026 -0.332,0.232 -0.482,0.64 -0.402,1.034 l 2.478,11.121 c 0.121,0.539 0.654,0.879 1.193,0.76 0.539,-0.119 0.884,-0.643 0.759,-1.194 l -1.952,-8.765 4.76,3.027 C -1.195,1.061 -0.755,1.051 -0.426,0.818 -0.154,0.629 0,0.322 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1413.5293,771.18893)"
+         clip-path="url(#clipPath461)"
+         id="path613" />
+      <path
+         d="m 0,0 c 0,-0.141 -0.029,-0.283 -0.092,-0.418 l -23.223,-50.547 c -0.23,-0.502 -0.824,-0.72 -1.326,-0.49 -0.502,0.23 -0.72,0.822 -0.49,1.326 L -2.915,-1.777 -37.536,-14.6 c -0.379,-0.141 -0.807,-0.039 -1.082,0.257 -0.273,0.299 -0.347,0.725 -0.174,1.098 l 25.561,55.638 c 0.23,0.501 0.824,0.72 1.326,0.49 0.502,-0.231 0.718,-0.824 0.49,-1.326 L -35.968,-11.886 -1.347,0.937 C -0.969,1.078 -0.541,0.976 -0.266,0.679 -0.092,0.49 0,0.246 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2135.5845,171.87333)"
+         clip-path="url(#clipPath462)"
+         id="path614" />
+      <path
+         d="m 0,0 c 0,-0.267 -0.106,-0.533 -0.316,-0.731 l -35.355,-33.056 30.212,-1.014 c 0.404,-0.013 0.761,-0.269 0.902,-0.648 0.142,-0.383 0.042,-0.805 -0.252,-1.082 l -33.721,-31.53 c -0.404,-0.377 -1.037,-0.355 -1.414,0.047 -0.375,0.406 -0.355,1.037 0.047,1.414 l 31.958,29.882 -30.212,1.013 c -0.405,0.014 -0.762,0.27 -0.902,0.648 -0.141,0.383 -0.044,0.805 0.252,1.082 L -1.683,0.73 C -1.279,1.107 -0.646,1.085 -0.27,0.683 -0.089,0.49 0,0.244 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2314.9235,424.80987)"
+         clip-path="url(#clipPath463)"
+         id="path615" />
+      <path
+         d="M 0,0 V -0.039 C -0.023,-0.592 -0.488,-1.021 -1.039,-1 l -46.622,1.863 21.899,-23.723 c 0.274,-0.295 0.344,-0.73 0.174,-1.097 -0.17,-0.367 -0.545,-0.596 -0.947,-0.58 l -53.97,2.155 c -0.55,0.022 -0.963,0.487 -0.961,1.039 0.024,0.553 0.489,0.982 1.039,0.961 l 51.559,-2.06 -21.9,23.723 c -0.275,0.297 -0.345,0.732 -0.174,1.097 0.171,0.367 0.546,0.596 0.947,0.58 L -0.961,1 C -0.422,0.978 0,0.535 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1925.4143,192.54053)"
+         clip-path="url(#clipPath464)"
+         id="path616" />
+      <path
+         d="M 0,0 C 0,-0.082 -0.01,-0.162 -0.029,-0.244 L -5.5,-21.977 c -0.137,-0.535 -0.68,-0.862 -1.215,-0.727 -0.533,0.135 -0.853,0.672 -0.726,1.215 l 4.883,19.392 -10.287,-6.148 c -0.347,-0.208 -0.785,-0.185 -1.108,0.055 -0.327,0.243 -0.471,0.664 -0.376,1.047 l 4.972,19.745 c 0.137,0.535 0.679,0.862 1.215,0.727 0.535,-0.137 0.857,-0.679 0.726,-1.215 L -11.8,-5.29 -1.513,0.857 C -1.166,1.066 -0.728,1.043 -0.404,0.803 -0.146,0.611 0,0.31 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,1668.8428,151.69827)"
+         clip-path="url(#clipPath465)"
+         id="path617" />
+      <path
+         d="m 0,0 c 0,-0.096 -0.014,-0.196 -0.043,-0.293 -0.162,-0.527 -0.72,-0.824 -1.249,-0.664 l -7.844,2.398 2.392,-4.499 c 0.189,-0.355 0.144,-0.791 -0.112,-1.105 -0.258,-0.311 -0.677,-0.438 -1.064,-0.32 l -11.177,3.415 c -0.525,0.162 -0.824,0.714 -0.664,1.25 0.162,0.527 0.721,0.823 1.25,0.663 l 8.867,-2.71 -2.392,4.499 c -0.19,0.355 -0.145,0.793 0.111,1.105 0.258,0.311 0.678,0.438 1.064,0.32 L -0.707,0.957 C -0.277,0.824 0,0.427 0,0"
+         style="fill:#2c3742 icc-color(sRGB-IEC61966-2, 0.1, 0.17298889, 0.21598816, 0.25898743);fill-opacity:1;fill-rule:nonzero;stroke:none"
+         transform="matrix(1.3333333,0,0,-1.3333333,2432.3339,23.285067)"
+         clip-path="url(#clipPath466)"
+         id="path618" />
+    </g>
+    <text
+       id="text619"
+       xml:space="preserve"
+       transform="translate(0,781.6484)"
+       style="letter-spacing:15px"
+       x="50%"
+       text-anchor="middle"><tspan
+         style="font-variant:normal;font-weight:100;font-stretch:normal;font-size:250px;font-family:'DM Sans';letter-spacing:15px;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+         sodipodi:role="line"
+         id="tspan619"
+         x="1287.5"
+         y="0">__TITLE__</tspan></text>
+    <text
+       id="text620"
+       xml:space="preserve"
+       y="990.9765"
+       x="50%"
+       text-anchor="middle"
+       style="font-size:16px;letter-spacing:20px;stroke-width:1.33333"><tspan
+         style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:131.979px;font-family:Sans;-inkscape-font-specification:'Sans, @wght=600';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'wght' 600;letter-spacing:20px;writing-mode:lr-tb;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.33333"
+         sodipodi:role="line"
+         id="tspan620"
+         x="1290"
+         y="990.9765">__DATE__</tspan></text>
+    <text
+       id="text621"
+       xml:space="preserve"
+       transform="translate(0,388.7292)"
+       x="50%"
+       text-anchor="middle"><tspan
+   style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:100px;font-family:'DM Sans';-inkscape-font-specification:'DM Sans, @opsz=40.0,wght=600';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;font-variation-settings:'opsz' 40, 'wght' 600;writing-mode:lr-tb;fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none"
+   sodipodi:role="line"
+   id="tspan621"
+   x="1281.5599"
+   y="0">__SITE__</tspan>    </text>
+    <path
+       id="path623"
+       d="M 1812.002,129.251 V 48.1 c -6.012,0 -10.887,-4.874 -10.887,-10.887 v 0 c 0,-6.013 4.875,-10.887 10.887,-10.887 v 0 h 22.057 v 39.552 h 12.799 l 18.225,-39.552 h 24.996 l -20.604,42.315 c 1.296,0.489 2.538,1.029 3.695,1.648 v 0 c 5.488,2.941 9.532,6.812 12.13,11.616 v 0 c 2.597,4.803 3.897,9.949 3.897,15.439 v 0 c 0,5.882 -1.349,11.223 -4.044,16.028 v 0 c -2.697,4.802 -6.788,8.649 -12.277,11.543 v 0 c -5.491,2.889 -12.45,4.336 -20.879,4.336 v 0 z m 22.057,-18.379 h 16.615 c 5.587,0 9.653,-1.301 12.204,-3.896 v 0 c 2.548,-2.599 3.822,-6.103 3.822,-10.514 v 0 c 0,-4.509 -1.3,-8.086 -3.896,-10.734 v 0 c -2.599,-2.646 -6.642,-3.969 -12.13,-3.969 v 0 h -16.615 z"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,1280)"
+       style="fill:url(#linearGradient623);stroke:none" />
+    <path
+       id="path626"
+       d="m 1812.002,151.025 c -6.012,0 -10.887,-4.874 -10.887,-10.887 v 0 -102.925 c 0,6.013 4.875,10.887 10.887,10.887 v 0 h 5.189 v 102.925 z"
+       transform="matrix(1.3333333,0,0,-1.3333333,0,1280)"
+       style="fill:url(#linearGradient626);stroke:none" />
+  </g>
+</svg>

--- a/new_issue.py
+++ b/new_issue.py
@@ -7,46 +7,59 @@ import datetime
 import tempfile
 import tomllib
 
+
 def create_issue(issue_number):
-	subprocess.run(['hugo', 'new', f'weekly/issue-{issue_number}/_index.md'])
+    subprocess.run(["hugo", "new", f"weekly/issue-{issue_number}/_index.md"])
+
 
 def create_issue_image(site_title, issue_number, period_start, period_end):
-	with open('assets/img/cover-template.svg') as f:
-		cover_template = f.read()
+    with open("assets/img/cover-template.svg") as f:
+        cover_template = f.read()
 
-	cover_template = cover_template.replace('__SITE__', site_title)
-	cover_template = cover_template.replace('__ISSUE__', issue_number)
-	cover_template = cover_template.replace('__DATE__', f'{period_start} - {period_end}')
+    cover_template = cover_template.replace("__SITE__", site_title)
+    cover_template = cover_template.replace("__ISSUE__", issue_number)
+    cover_template = cover_template.replace(
+        "__DATE__", f"{period_start} - {period_end}"
+    )
 
-	with tempfile.TemporaryDirectory() as tempdir:
-		cover_path = pathlib.Path(tempdir) / 'cover.svg'
-		with open(cover_path, 'w') as f:
-			f.write(cover_template)
+    with tempfile.TemporaryDirectory() as tempdir:
+        cover_path = pathlib.Path(tempdir) / "cover.svg"
+        with open(cover_path, "w") as f:
+            f.write(cover_template)
 
-		subprocess.run(['inkscape', str(cover_path), '-e', f'content/weekly/issue-{issue_number}/cover.png'])
-		
+        subprocess.run(
+            [
+                "inkscape",
+                str(cover_path),
+                "-e",
+                f"content/weekly/issue-{issue_number}/cover.png",
+            ]
+        )
+
 
 def get_latest_issue():
-	issues = list(pathlib.Path('content/weekly').iterdir())
-	latest_issue = max(issues, key=lambda x: int(x.name.split('-')[1]))
-	return latest_issue.name.split('-')[1]
+    issues = list(pathlib.Path("content/weekly").iterdir())
+    latest_issue = max(issues, key=lambda x: int(x.name.split("-")[1]))
+    return latest_issue.name.split("-")[1]
 
-if __name__ == '__main__':
-	with open('hugo.toml', "rb") as f:
-		hugo_config = tomllib.load(f)
 
-	parser = argparse.ArgumentParser(description='Create a new issue')
-	parser.add_argument('--issue', type=int, help='Issue number')
-	args = parser.parse_args()
+if __name__ == "__main__":
+    with open("hugo.toml", "rb") as f:
+        hugo_config = tomllib.load(f)
 
-	if args.issue:
-		new_issue = args.issue
-	else:
-		latest_issue = get_latest_issue()
-		new_issue = int(latest_issue) + 1
+    parser = argparse.ArgumentParser(description="Create a new issue")
+    parser.add_argument("--issue", type=int, help="Issue number")
+    args = parser.parse_args()
 
-	period_start = datetime.datetime.now().strftime('%Y-%m-%d')
-	period_end = (datetime.datetime.now() + datetime.timedelta(days=7)).strftime('%Y-%m-%d')
+    if args.issue:
+        new_issue = args.issue
+    else:
+        latest_issue = get_latest_issue()
+        new_issue = int(latest_issue) + 1
 
-	create_issue(new_issue)
-	
+    period_start = datetime.datetime.now().strftime("%Y-%m-%d")
+    period_end = (datetime.datetime.now() + datetime.timedelta(days=7)).strftime(
+        "%Y-%m-%d"
+    )
+
+    create_issue(new_issue)

--- a/new_issue.py
+++ b/new_issue.py
@@ -58,10 +58,12 @@ def create_issue(
         subprocess.CalledProcessError: If the Hugo command fails
         IOError: If any of the Python file operations fail
     """
+	# Use the Hugo CLI to create a new issue
     subprocess.run(
         ["hugo", "new", f"weekly/issue-{issue_number}/_index.md"], check=True
     )
 
+	# Read the content of the new file
     with open(f"content/weekly/issue-{issue_number}/_index.md", "r") as f:
         content = f.read()
 
@@ -76,6 +78,7 @@ def create_issue(
 
     content = "\n".join(lines)
 
+	# Overwrite the file with the new content
     with open(f"content/weekly/issue-{issue_number}/_index.md", "w") as f:
         f.write(content)
 

--- a/new_issue.py
+++ b/new_issue.py
@@ -8,19 +8,104 @@ import tempfile
 import tomllib
 
 
-def create_issue(issue_number):
-    subprocess.run(["hugo", "new", f"weekly/issue-{issue_number}/_index.md"])
+def get_period_string(
+    start: datetime.datetime,
+    end: datetime.datetime,
+    year: bool = False,
+) -> str:
+    """Get a string representation of the period
+
+    Args:
+        start (datetime.datetime): The start of the period
+        end (datetime.datetime): The end of the period
+        year (bool, optional): Include the year in the string. Defaults to False.
+
+    Returns:
+        str: The period string
+    """
+    if period_start.year == period_end.year:
+        if period_start.month == period_end.month:
+            period_string = (
+                f"{period_start.strftime('%B %d')} - {period_end.strftime('%d')}"
+            )
+        else:
+            period_string = (
+                f"{period_start.strftime('%B %d')} - {period_end.strftime('%B %d')}"
+            )
+
+        if year:
+            period_string += f", {period_start.year}"
+
+    else:
+        period_string = (
+            f"{period_start.strftime('%B %d, %Y')} - {period_end.strftime('%B %d, %Y')}"
+        )
+
+    return period_string
 
 
-def create_issue_image(site_title, issue_number, period_start, period_end):
+def create_issue(
+    issue_number: int, period_start: datetime.datetime, period_end: datetime.datetime
+) -> None:
+    """Create a new issue
+
+    Args:
+        issue_number (int): The issue number
+        period_start (datetime.datetime): The start of the period
+        period_end (datetime.datetime): The end of the period
+
+    Raises:
+        subprocess.CalledProcessError: If the Hugo command fails
+        IOError: If any of the Python file operations fail
+    """
+    subprocess.run(
+        ["hugo", "new", f"weekly/issue-{issue_number}/_index.md"], check=True
+    )
+
+    with open(f"content/weekly/issue-{issue_number}/_index.md", "r") as f:
+        content = f.read()
+
+    # Get line that starts with "title" and replace it with the new title
+    lines = content.split("\n")
+
+    period_string = get_period_string(period_start, period_end, True)
+
+    for i, line in enumerate(lines):
+        if line.startswith("title:"):
+            lines[i] = f"title: Issue {issue_number} - {period_string}"
+
+    content = "\n".join(lines)
+
+    with open(f"content/weekly/issue-{issue_number}/_index.md", "w") as f:
+        f.write(content)
+
+
+def create_issue_image(
+    site_title: str,
+    issue_number: int,
+    period_start: datetime.datetime,
+    period_end: datetime.datetime,
+) -> None:
+    """Create a cover image for the issue
+
+    Args:
+        site_title (str): The title of the site
+        issue_number (int): The issue number
+        period_start (datetime.datetime): The start of the period
+        period_end (datetime.datetime): The end of the period
+
+    Raises:
+        FileNotFoundError: If the cover template is not found
+        IOError: If any of the file operations fail
+    """
     with open("assets/img/cover-template.svg") as f:
         cover_template = f.read()
 
+    period_string = get_period_string(period_start, period_end)
+
     cover_template = cover_template.replace("__SITE__", site_title)
-    cover_template = cover_template.replace("__ISSUE__", issue_number)
-    cover_template = cover_template.replace(
-        "__DATE__", f"{period_start} - {period_end}"
-    )
+    cover_template = cover_template.replace("__TITLE__", f"Issue {issue_number}")
+    cover_template = cover_template.replace("__DATE__", period_string)
 
     with tempfile.TemporaryDirectory() as tempdir:
         cover_path = pathlib.Path(tempdir) / "cover.svg"
@@ -31,16 +116,21 @@ def create_issue_image(site_title, issue_number, period_start, period_end):
             [
                 "inkscape",
                 str(cover_path),
-                "-e",
+                "--export-filename",
                 f"content/weekly/issue-{issue_number}/cover.png",
             ]
         )
 
 
-def get_latest_issue():
+def get_latest_issue() -> int:
+    """Get the latest issue number from the weekly directory
+
+    Returns:
+        int: The latest issue number
+    """
     issues = list(pathlib.Path("content/weekly").iterdir())
     latest_issue = max(issues, key=lambda x: int(x.name.split("-")[1]))
-    return latest_issue.name.split("-")[1]
+    return int(latest_issue.name.split("-")[1])
 
 
 if __name__ == "__main__":
@@ -49,7 +139,30 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description="Create a new issue")
     parser.add_argument("--issue", type=int, help="Issue number")
+    parser.add_argument("--period-start", type=str, help="Period start")
+    parser.add_argument("--period-end", type=str, help="Period end")
+    parser.add_argument("--quiet", "-q", action="store_true", help="Quiet mode")
     args = parser.parse_args()
+
+    if not (args.period_start and args.period_end):
+        if not args.quiet:
+            # Query the user for the period start and end
+            today = datetime.datetime.now().strftime("%Y-%m-%d")
+
+            period_start_str = input(f"Period start [{today}]: ") or today
+            period_start = datetime.datetime.strptime(period_start_str, "%Y-%m-%d")
+
+            seven_days = (period_start + datetime.timedelta(days=7)).strftime(
+                "%Y-%m-%d"
+            )
+
+            period_end_str = input(f"Period end [{seven_days}]: ") or seven_days
+            period_end = datetime.datetime.strptime(period_end_str, "%Y-%m-%d")
+
+        else:
+            # Assume the period is the next 7 days - # TODO: Check if this is correct
+            period_start = datetime.datetime.now()
+            period_end = datetime.datetime.now() + datetime.timedelta(days=7)
 
     if args.issue:
         new_issue = args.issue
@@ -57,9 +170,5 @@ if __name__ == "__main__":
         latest_issue = get_latest_issue()
         new_issue = int(latest_issue) + 1
 
-    period_start = datetime.datetime.now().strftime("%Y-%m-%d")
-    period_end = (datetime.datetime.now() + datetime.timedelta(days=7)).strftime(
-        "%Y-%m-%d"
-    )
-
-    create_issue(new_issue)
+    create_issue(new_issue, period_start, period_end)
+    create_issue_image(hugo_config["title"], new_issue, period_start, period_end)

--- a/new_issue.py
+++ b/new_issue.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+import subprocess
+import pathlib
+import argparse
+import datetime
+import tempfile
+import tomllib
+
+def create_issue(issue_number):
+	subprocess.run(['hugo', 'new', f'weekly/issue-{issue_number}/_index.md'])
+
+def create_issue_image(site_title, issue_number, period_start, period_end):
+	with open('assets/img/cover-template.svg') as f:
+		cover_template = f.read()
+
+	cover_template = cover_template.replace('__SITE__', site_title)
+	cover_template = cover_template.replace('__ISSUE__', issue_number)
+	cover_template = cover_template.replace('__DATE__', f'{period_start} - {period_end}')
+
+	with tempfile.TemporaryDirectory() as tempdir:
+		cover_path = pathlib.Path(tempdir) / 'cover.svg'
+		with open(cover_path, 'w') as f:
+			f.write(cover_template)
+
+		subprocess.run(['inkscape', str(cover_path), '-e', f'content/weekly/issue-{issue_number}/cover.png'])
+		
+
+def get_latest_issue():
+	issues = list(pathlib.Path('content/weekly').iterdir())
+	latest_issue = max(issues, key=lambda x: int(x.name.split('-')[1]))
+	return latest_issue.name.split('-')[1]
+
+if __name__ == '__main__':
+	with open('hugo.toml', "rb") as f:
+		hugo_config = tomllib.load(f)
+
+	parser = argparse.ArgumentParser(description='Create a new issue')
+	parser.add_argument('--issue', type=int, help='Issue number')
+	args = parser.parse_args()
+
+	if args.issue:
+		new_issue = args.issue
+	else:
+		latest_issue = get_latest_issue()
+		new_issue = int(latest_issue) + 1
+
+	period_start = datetime.datetime.now().strftime('%Y-%m-%d')
+	period_end = (datetime.datetime.now() + datetime.timedelta(days=7)).strftime('%Y-%m-%d')
+
+	create_issue(new_issue)
+	


### PR DESCRIPTION
This PR addresses the first point in the HedgeDoc ToDo document:

- Added a Python script that handles the creation of new weekly posts, `new_issue.py`. Upon running, it asks for dates to use in the post title, creates a new post in `content/weekly` using `hugo new`, as well as a `cover.png` for that post using `inkscape`.
- Updated the SVG template such that the text is automatically centered (`x="50%" text-anchor="middle"`).

The script can be extended in the future to handle the required screenshots too, but I'll have to think of an elegant solution for that first.